### PR TITLE
change package `sklearn` to `scikit-learn`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy
 scipy
 biopython
-sklearn
+scikit-learn
 networkx


### PR DESCRIPTION
The old `sklearn` will cause error during installation, see https://github.com/scikit-learn/sklearn-pypi-package.
