### PR TITLE
Chore/pylint mypy pass

### DIFF
--- a/big_scape/comparison/binning.py
+++ b/big_scape/comparison/binning.py
@@ -443,9 +443,9 @@ class MissingRecordPairGenerator(RecordPairGenerator):
     already in the database
     """
 
-    def __init__(self, bin):
-        super().__init__(bin.label)
-        self.bin = bin
+    def __init__(self, pair_generator):
+        super().__init__(pair_generator.label)
+        self.bin = pair_generator
 
     def num_pairs(self) -> int:
         distance_table = DB.metadata.tables["distance"]

--- a/big_scape/comparison/binning.py
+++ b/big_scape/comparison/binning.py
@@ -279,6 +279,10 @@ class RefToRefRecordPairGenerator(RecordPairGenerator):
         Returns:
             set[BGCRecord]: A set of reference nodes that are connected to other reference nodes
         """
+
+        if not DB.metadata:
+            raise RuntimeError("DB.metadata is None")
+
         distance_table = DB.metadata.tables["distance"]
         bgc_record_table = DB.metadata.tables["bgc_record"]
         gbk_table = DB.metadata.tables["gbk"]
@@ -324,6 +328,10 @@ class RefToRefRecordPairGenerator(RecordPairGenerator):
             int: The number of reference nodes that are not connected to other reference
             nodes
         """
+
+        if not DB.metadata:
+            raise RuntimeError("DB.metadata is None")
+
         distance_table = DB.metadata.tables["distance"]
         bgc_record_table = DB.metadata.tables["bgc_record"]
         gbk_table = DB.metadata.tables["gbk"]
@@ -363,6 +371,10 @@ class RefToRefRecordPairGenerator(RecordPairGenerator):
             set[BGCRecord]: A set of reference nodes that are not connected to other
             reference nodes
         """
+
+        if not DB.metadata:
+            raise RuntimeError("DB.metadata is None")
+
         distance_table = DB.metadata.tables["distance"]
         bgc_record_table = DB.metadata.tables["bgc_record"]
         gbk_table = DB.metadata.tables["gbk"]
@@ -407,6 +419,10 @@ class RefToRefRecordPairGenerator(RecordPairGenerator):
             int: The number of reference nodes that are not connected to other reference
             nodes
         """
+
+        if not DB.metadata:
+            raise RuntimeError("DB.metadata is None")
+
         distance_table = DB.metadata.tables["distance"]
         bgc_record_table = DB.metadata.tables["bgc_record"]
         gbk_table = DB.metadata.tables["gbk"]
@@ -448,6 +464,9 @@ class MissingRecordPairGenerator(RecordPairGenerator):
         self.bin = pair_generator
 
     def num_pairs(self) -> int:
+        if not DB.metadata:
+            raise RuntimeError("DB.metadata is None")
+
         distance_table = DB.metadata.tables["distance"]
 
         # get all region._db_id in the bin where the region_a_id and region_b_id are in the
@@ -465,6 +484,9 @@ class MissingRecordPairGenerator(RecordPairGenerator):
         return self.bin.num_pairs() - existing_distance_count
 
     def generate_pairs(self, legacy_sorting=False) -> Generator[RecordPair, None, None]:
+        if not DB.metadata:
+            raise RuntimeError("DB.metadata is None")
+
         distance_table = DB.metadata.tables["distance"]
 
         # get all region._db_id in the bin

--- a/big_scape/comparison/comparable_region.py
+++ b/big_scape/comparison/comparable_region.py
@@ -9,13 +9,10 @@ from typing import TYPE_CHECKING, Optional
 
 # from other modules
 from big_scape.genbank import BGCRecord
-
+from big_scape.hmm import HSP
 
 # from this module
 from .legacy_lcs import legacy_find_cds_lcs
-
-# from other modules
-from big_scape.hmm import HSP
 
 
 # from circular imports
@@ -253,7 +250,15 @@ class ComparableRegion:
             if i == b_stop:
                 b_region_str = "STOP"
 
-            log_line = f"{i:<3} {a_domains:<25} {a_region_str:<10} {b_domains:<25} {b_region_str:<10}"
+            log_line = " ".join(
+                [
+                    f"{i:<3}",
+                    f"{a_domains:<25}",
+                    f"{a_region_str:<10}",
+                    f"{b_domains:<25}",
+                    f"{b_region_str:<10}",
+                ]
+            )
             logging.debug(log_line)
 
     def __eq__(self, __o: object) -> bool:

--- a/big_scape/comparison/legacy_extend.py
+++ b/big_scape/comparison/legacy_extend.py
@@ -14,6 +14,8 @@ from big_scape.parameters.constants import (
 from big_scape.genbank import CDS, BGCRecord
 from big_scape.comparison import ComparableRegion, RecordPair
 
+import big_scape.enums as bs_enums
+
 
 def reset_expansion(
     comparable_region: ComparableRegion, a_start=0, a_stop=None, b_start=0, b_stop=None
@@ -404,7 +406,9 @@ def expand_score(
 
 
 def legacy_needs_expand_pair(
-    pair: RecordPair, alignment_mode: str, extend_slice_cutoff=MIN_LCS_LEN
+    pair: RecordPair,
+    alignment_mode: bs_enums.ALIGNMENT_MODE,
+    extend_slice_cutoff=MIN_LCS_LEN,
 ) -> bool:  # pragma no cover
     """Returns False if:
 
@@ -429,16 +433,21 @@ def legacy_needs_expand_pair(
 def legacy_needs_extend(
     region_a: BGCRecord,
     region_b: BGCRecord,
-    alignment_mode: str,
+    alignment_mode: bs_enums.ALIGNMENT_MODE,
     a_start: int,
     a_stop: int,
     extend_slice_cutoff=MIN_LCS_LEN,
 ) -> bool:  # pragma no cover
-    if alignment_mode == "global":
+    if alignment_mode == bs_enums.ALIGNMENT_MODE.GLOBAL:
         return False
 
-    if alignment_mode == "auto" and not (region_a.contig_edge and region_b.contig_edge):
+    on_contig = region_a.contig_edge and region_b.contig_edge
+
+    if alignment_mode == bs_enums.ALIGNMENT_MODE.AUTO and not on_contig:
         return False
+
+    # after above logic, alignment mode is auto and either region_a or region_b is on
+    # a contig edge, or alignment mode is local
 
     lcs_extend_len = a_stop - 1 - a_start
     if (

--- a/big_scape/comparison/legacy_workflow_alt.py
+++ b/big_scape/comparison/legacy_workflow_alt.py
@@ -17,6 +17,8 @@ from typing import Generator, Callable, Optional, TypeVar
 # from other modules
 from big_scape.distances import calc_jaccard_pair, calc_ai_pair, calc_dss_pair_legacy
 
+import big_scape.enums as bs_enums
+
 # from this module
 from .binning import RecordPairGenerator, RecordPair
 from .legacy_bins import LEGACY_BINS
@@ -53,7 +55,7 @@ def batch_generator(generator: Generator[T, None, None], batch_size: int) -> lis
 
 def generate_edges(
     pair_generator: RecordPairGenerator,
-    alignment_mode: str,
+    alignment_mode: bs_enums.ALIGNMENT_MODE,
     cores: int,
     callback: Optional[Callable] = None,
     batch_size=100,
@@ -145,7 +147,9 @@ def generate_edges(
                 break
 
 
-def do_lcs_pair(pair: RecordPair, alignment_mode) -> bool:  # pragma no cover
+def do_lcs_pair(
+    pair: RecordPair, alignment_mode: bs_enums.ALIGNMENT_MODE
+) -> bool:  # pragma no cover
     """Find the longest common subsequence of protein domains between two regions
 
     Args:
@@ -194,7 +198,7 @@ def expand_pair(pair: RecordPair) -> float:
 
 
 def calculate_scores_pair(
-    data: tuple[list[RecordPair], str, str]
+    data: tuple[list[RecordPair], bs_enums.ALIGNMENT_MODE, str]
 ) -> list[tuple[float, float, float, float]]:  # pragma no cover
     """Calculate the scores for a list of pairs
 

--- a/big_scape/data/partial_task.py
+++ b/big_scape/data/partial_task.py
@@ -55,6 +55,9 @@ def get_input_data_state(gbks: list[GBK]) -> bs_enums.INPUT_TASK:
     if distance_count == 0:
         return bs_enums.INPUT_TASK.NO_DATA
 
+    if not DB.metadata:
+        raise RuntimeError("DB.metadata is None")
+
     gbk_table = DB.metadata.tables["gbk"]
 
     # get set of gbks in database
@@ -90,6 +93,9 @@ def get_missing_gbks(gbks: list[GBK]) -> list[GBK]:
     """
     # dictionary of gbk path to gbk object
     gbk_dict = {str(gbk.path): gbk for gbk in gbks}
+
+    if not DB.metadata:
+        raise RuntimeError("DB.metadata is None")
 
     gbk_table = DB.metadata.tables["gbk"]
 
@@ -147,6 +153,10 @@ def get_cds_to_scan(gbks: list[GBK]) -> list[CDS]:
     cds_to_scan = []
 
     # get a list of database cds_ids that are present in the cds_scanned table
+
+    if not DB.metadata:
+        raise RuntimeError("DB.metadata is None")
+
     scanned_cds_table = DB.metadata.tables["scanned_cds"]
     select_query = select(scanned_cds_table.c.cds_id)
     scanned_cds_ids = set(DB.execute(select_query))
@@ -190,11 +200,17 @@ def get_comparison_data_state(gbks: list[GBK]) -> bs_enums.COMPARISON_TASK:
 
     # check if all record ids are present in the comparison region ids
 
+    if not DB.metadata:
+        raise RuntimeError("DB.metadata is None")
+
     bgc_record_table = DB.metadata.tables["bgc_record"]
 
     select_statement = select(bgc_record_table.c.id)
 
     record_ids = set(DB.execute(select_statement).fetchall())
+
+    if not DB.metadata:
+        raise RuntimeError("DB.metadata is None")
 
     distance_table = DB.metadata.tables["distance"]
 
@@ -224,6 +240,10 @@ def get_missing_distances(
     Yields:
         Generator[BGCPair]: generator of BGCPairs that are missing from the network
     """
+
+    if not DB.metadata:
+        raise RuntimeError("DB.metadata is None")
+
     distance_table = DB.metadata.tables["distance"]
 
     # get all region._db_id in the bin

--- a/big_scape/data/sqlite.py
+++ b/big_scape/data/sqlite.py
@@ -1,8 +1,9 @@
 # from python
+from __future__ import annotations
 import logging
 from pathlib import Path
-from typing import Generator, List
-from sqlite3 import Connection as Sqlite3Connection
+from typing import Generator, Optional, Any
+import sqlite3
 
 # from dependencies
 from sqlalchemy import (
@@ -10,6 +11,8 @@ from sqlalchemy import (
     Connection,
     MetaData,
     Compiled,
+    Select,
+    Insert,
     CursorResult,
     create_engine,
     func,
@@ -25,14 +28,20 @@ from big_scape.errors import DBClosedError, DBAlreadyOpenError
 class DB:
     """Class to manage database interaction"""
 
-    engine: Engine = None
-    connection: Connection = None
-    metadata: MetaData = None
+    engine: Optional[Engine] = None
+    connection: Optional[Connection] = None
+    metadata: Optional[MetaData] = None
 
     @staticmethod
     def opened() -> bool:
         """Returns true if database is already openened"""
-        return DB.connection is not None and not DB.connection.closed
+        if DB.engine is None or DB.connection is None:
+            return False
+
+        if DB.connection.closed:
+            return False
+
+        return True
 
     @staticmethod
     def reflect() -> None:
@@ -44,6 +53,9 @@ class DB:
         if not DB.opened():
             raise DBClosedError()
 
+        if DB.engine is None:
+            raise RuntimeError("DB.engine is None")
+
         DB.metadata = MetaData()
         DB.metadata.reflect(bind=DB.engine)
 
@@ -52,6 +64,9 @@ class DB:
         """Populates the database with tables"""
         if not DB.opened():
             raise DBClosedError()
+
+        if not DB.connection:
+            raise RuntimeError("DB.connection is None")
 
         creation_queries = read_schema(Path(DB_SCHEMA_PATH))
 
@@ -87,6 +102,12 @@ class DB:
         if not DB.opened():
             raise DBClosedError()
 
+        if not DB.engine:
+            raise RuntimeError("DB.engine is None")
+
+        if not DB.connection:
+            raise RuntimeError("DB.connection is None")
+
         logging.info("Saving database to %s", db_path)
 
         db_path.parent.mkdir(parents=True, exist_ok=True)
@@ -95,13 +116,23 @@ class DB:
         file_engine.connect()
 
         # from
-        raw_memory_connection: Sqlite3Connection = (
-            DB.engine.raw_connection().driver_connection
-        )
+
+        raw_memory_connection = DB.engine.raw_connection().driver_connection
+
+        if not isinstance(raw_memory_connection, sqlite3.Connection):
+            raise TypeError(
+                "Expected raw connection to be of type sqlite3.Connection, got "
+                + str(type(raw_memory_connection))
+            )
+
         # to
-        raw_file_connection: Sqlite3Connection = (
-            file_engine.raw_connection().driver_connection
-        )
+        raw_file_connection = file_engine.raw_connection().driver_connection
+
+        if not isinstance(raw_file_connection, sqlite3.Connection):
+            raise TypeError(
+                "Expected raw connection to be of type sqlite3.Connection, got "
+                + str(type(raw_file_connection))
+            )
 
         raw_memory_connection.backup(raw_file_connection)
 
@@ -123,14 +154,29 @@ class DB:
 
         DB.open_memory_connection()
 
+        if not DB.engine:
+            raise RuntimeError("DB.engine is None")
+
+        if not DB.connection:
+            raise RuntimeError("DB.connection is None")
+
         # from
-        raw_file_connection: Sqlite3Connection = (
-            file_engine.raw_connection().driver_connection
-        )
+        raw_file_connection = file_engine.raw_connection().driver_connection
+
+        if not isinstance(raw_file_connection, sqlite3.Connection):
+            raise TypeError(
+                "Expected raw connection to be of type sqlite3.Connection, got "
+                + str(type(raw_file_connection))
+            )
+
         # to
-        raw_memory_connection: Sqlite3Connection = (
-            DB.engine.raw_connection().driver_connection
-        )
+        raw_memory_connection = DB.engine.raw_connection().driver_connection
+
+        if not isinstance(raw_memory_connection, sqlite3.Connection):
+            raise TypeError(
+                "Expected raw connection to be of type sqlite3.Connection, got "
+                + str(type(raw_memory_connection))
+            )
 
         # backup only writes those tables that have data, it seems
         DB.create_tables()
@@ -142,15 +188,27 @@ class DB:
     @staticmethod
     def close_db() -> None:
         """Closes the database connection. This does not save the database to disk"""
+        if not DB.opened():
+            return
+
+        if not DB.connection:
+            raise RuntimeError("DB.connection is None")
+
         DB.connection.close()
 
     @staticmethod
     def execute_raw_query(query: str) -> CursorResult:
         """Executes a raw simple query. Should only be used for very short queries"""
+        if not DB.opened():
+            raise DBClosedError()
+
+        if not DB.connection:
+            raise RuntimeError("DB.connection is None")
+
         return DB.connection.execute(text(query))
 
     @staticmethod
-    def execute(query: Compiled, commit=True) -> CursorResult:
+    def execute(query: Compiled | Select[Any] | Insert, commit=True) -> CursorResult:
         """Wrapper for SQLAlchemy.connection.execute expecting a Compiled query
 
         Arguments:
@@ -158,8 +216,13 @@ class DB:
 
         This function is meant for single queries.
         """
+        if not DB.opened():
+            raise DBClosedError()
 
-        cursor_result = DB.connection.execute(query)
+        if not DB.connection:
+            raise RuntimeError("DB.connection is None")
+
+        cursor_result = DB.connection.execute(query)  # type: ignore
 
         if commit:
             DB.connection.commit()
@@ -173,6 +236,12 @@ class DB:
 
         NOTE: may be redundant if we turn off journaling
         """
+        if not DB.opened():
+            raise DBClosedError()
+
+        if not DB.connection:
+            raise RuntimeError("DB.connection is None")
+
         DB.connection.commit()
 
     @staticmethod
@@ -185,6 +254,12 @@ class DB:
         Returns:
             int: number of rows in the table
         """
+        if not DB.opened():
+            raise DBClosedError()
+
+        if not DB.metadata:
+            raise RuntimeError("DB.metadata is None")
+
         table_metadata = DB.metadata.tables[table_name]
         return DB.execute(
             select(func.count("*")).select_from(table_metadata)
@@ -203,6 +278,13 @@ class DB:
         Yields:
             Generator[tuple]: generator of tuples of rows from the table
         """
+
+        if not DB.opened():
+            raise DBClosedError()
+
+        if not DB.metadata:
+            raise RuntimeError("DB.metadata is None")
+
         table_metadata = DB.metadata.tables[table_name]
         table_select = select(table_metadata)
         table_select = table_select.execution_options(stream_results=True)
@@ -212,20 +294,20 @@ class DB:
             rows = cursor.fetchmany(batch_size)
             if not rows:
                 break
-            yield rows
+            yield tuple(rows)
 
 
-def read_schema(path: Path) -> List[str]:
+def read_schema(path: Path) -> list[str]:
     """Read an .sql schema from a file"""
     with open(path, encoding="utf-8") as schema_file:
         return text_to_queries(schema_file.readlines())
 
 
-def text_to_queries(schema_lines: List[str]) -> list[str]:
+def text_to_queries(schema_lines: list[str]) -> list[str]:
     """Convert list of lines from an .sql file to a list of queries
 
     Args:
-        schema_lines (List[str]): list of lines from an .sql file
+        schema_lines (list[str]): list of lines from an .sql file
 
     Returns:
         list[str]: list of queries that can be executed

--- a/big_scape/diagnostics/profiler.py
+++ b/big_scape/diagnostics/profiler.py
@@ -130,7 +130,7 @@ def make_plots(
     if stat_type not in stat_types:
         raise ValueError("Invalid stat type. Expected one of: %s" % stat_types)
 
-    stats_df = pd.DataFrame.from_dict(stats_dict, orient="index")
+    stats_df = pd.DataFrame.from_dict(stats_dict, orient="index")  # type: ignore
     stats_df = stats_df.fillna(0.0)
     main_df = stats_df.pop("MAIN")
 

--- a/big_scape/diagnostics/profiler.py
+++ b/big_scape/diagnostics/profiler.py
@@ -175,7 +175,7 @@ def collect_consumption(
 
         while threading.main_thread().is_alive():
             if not command_queue.empty():
-                command, args = command_queue.get()
+                command, _ = command_queue.get()
                 if command == 1:
                     break
 
@@ -211,8 +211,18 @@ def collect_consumption(
             cpu_dict[elapsed_time]["MAIN"] = m_cpu_percent
 
             # print 'MAIN' line to profile report
-            main_line = f"{prefix_time},MAIN,{m_cpu_percent:.2f},1,{m_mem_mb:.2f},{m_mem_percent:.2f}\n"
-            profile_log.write(main_line)
+            main_line = ",".join(
+                [
+                    prefix_time,
+                    "MAIN",
+                    str(round(m_cpu_percent, 2)),
+                    "1",
+                    str(round(m_mem_mb, 2)),
+                    str(round(m_mem_percent, 2)),
+                ]
+            )
+
+            profile_log.write(main_line + "\n")
 
             # start multi/cumulative stats
             total_cpu_percent = m_cpu_percent
@@ -223,8 +233,9 @@ def collect_consumption(
             for child_process in main_process.children(recursive=True):
                 c_pid = f"CHILD_{child_process.pid}"
                 try:
-                    # in case a child process was created between the time of generating the set_child_cpu_time_dict
-                    # and now, i.e. during the elapsed interval
+                    # in case a child process was created between the time of generating
+                    # the set_child_cpu_time_dict and now, i.e. during the elapsed
+                    # interval
                     if c_pid not in set_child_cpu_time_dict:
                         continue
 

--- a/big_scape/distances/dss.py
+++ b/big_scape/distances/dss.py
@@ -103,6 +103,8 @@ def get_aligned_string_dist(string_a: str, string_b: str) -> float:
 def get_sum_seq_dist(
     a_domain_list, b_domain_list, a_domain_dict, b_domain_dict, shared_domain
 ) -> tuple[float, int]:  # pragma no cover
+    """Get the sum of the distances between the sequences of two domains"""
+
     a_domain_count = len(a_domain_dict[shared_domain])
     b_domain_count = len(b_domain_dict[shared_domain])
 
@@ -129,11 +131,24 @@ def get_sum_seq_dist(
 
 
 def get_distance_from_shared(
-    bgc_pair: RecordPair, anchor_domains: set[str]
+    record_pair: RecordPair, anchor_domains: set[str]
 ):  # pragma no cover
-    domain_set_a, domain_set_b = bgc_pair.comparable_region.get_domain_sets()
-    a_domain_list, b_domain_list = bgc_pair.comparable_region.get_domain_lists()
-    a_domain_dict, b_domain_dict = bgc_pair.comparable_region.get_domain_dicts()
+    """Get the distance for anchor and non-anchor domains for a pair of BGCs based upon
+    the shared domains. Each domain that is shared adds a distance based upon the
+    alignment of the domain sequences
+
+    Args:
+        record_pair (RecordPair): RecordPair object to calculate this distance metric
+        for
+
+    Returns:
+        tuple[float, float]: Two scores for the distance of non-anchor domains and of
+        anchor domains, respectively
+    """
+
+    domain_set_a, domain_set_b = record_pair.comparable_region.get_domain_sets()
+    a_domain_list, b_domain_list = record_pair.comparable_region.get_domain_lists()
+    a_domain_dict, b_domain_dict = record_pair.comparable_region.get_domain_dicts()
 
     intersect = domain_set_a & domain_set_b
 
@@ -159,8 +174,19 @@ def get_distance_from_shared(
 
 
 def calc_dss_pair(
-    bgc_pair: RecordPair, anchor_domains: Optional[set[str]] = None
+    record_pair: RecordPair, anchor_domains: Optional[set[str]] = None
 ) -> float:  # pragma no cover
+    """Calculate the DSS for a pair of records
+
+    Args:
+        record_pair (RecordPair): Pair of records to calculate DSS for
+        anchor_domains (Optional[set[str]], optional): Set of anchor domains. Defaults
+            to None.
+
+    Returns:
+        float: DSS score for the pair of records
+    """
+
     # intialize an empty set of anchor domains if it is set to None
     if anchor_domains is None:
         anchor_domains = set(LEGACY_ANCHOR_DOMAINS)
@@ -168,7 +194,7 @@ def calc_dss_pair(
     # initialize the distances by getting the distances from all unshared domains, which
     # all add 1 to the difference
     distance_anchor, distance_non_anchor = get_distance_from_unshared(
-        bgc_pair, anchor_domains
+        record_pair, anchor_domains
     )
 
     # since we know we added whole numbers in the above function, we can re-use the
@@ -183,7 +209,7 @@ def calc_dss_pair(
         s_dist_non_anchor,
         s_domains_anchor,
         s_domains_non_anchor,
-    ) = get_distance_from_shared(bgc_pair, anchor_domains)
+    ) = get_distance_from_shared(record_pair, anchor_domains)
 
     distance_anchor += s_dist_anchor
     distance_non_anchor += s_dist_non_anchor

--- a/big_scape/distances/dss.py
+++ b/big_scape/distances/dss.py
@@ -108,7 +108,7 @@ def get_sum_seq_dist(
     a_domain_count = len(a_domain_dict[shared_domain])
     b_domain_count = len(b_domain_dict[shared_domain])
 
-    distance_matrix = ndarray((a_domain_count, b_domain_count))
+    distance_matrix: ndarray = ndarray((a_domain_count, b_domain_count))
 
     for a_idx, a_list_idx in enumerate(a_domain_dict[shared_domain]):
         for b_idx, b_list_idx in enumerate(b_domain_dict[shared_domain]):

--- a/big_scape/distances/legacy_dss.py
+++ b/big_scape/distances/legacy_dss.py
@@ -175,7 +175,7 @@ def get_sum_seq_dist(
     a_domain_count = len(a_domain_dict[shared_domain])
     b_domain_count = len(b_domain_dict[shared_domain])
 
-    distance_matrix = ndarray((a_domain_count, b_domain_count))
+    distance_matrix: ndarray = ndarray((a_domain_count, b_domain_count))
 
     for a_idx, a_list_idx in enumerate(a_domain_dict[shared_domain]):
         for b_idx, b_list_idx in enumerate(b_domain_dict[shared_domain]):

--- a/big_scape/distances/mix.py
+++ b/big_scape/distances/mix.py
@@ -48,7 +48,10 @@ def calculate_distances_mix(
 
             if done_pairs % mod == 0:
                 logging.info(
-                    f"{done_pairs}/{mix_bin.num_pairs()} ({done_pairs/mix_bin.num_pairs():.2%})"
+                    "%d/%d (%.2f%%)",
+                    done_pairs,
+                    mix_bin.num_pairs(),
+                    done_pairs / mix_bin.num_pairs() * 100,
                 )
 
         mix_edges = bs_comparison.generate_edges(

--- a/big_scape/distances/query.py
+++ b/big_scape/distances/query.py
@@ -79,7 +79,12 @@ def calculate_distances_query(
                 mod = 1
 
             if done_pairs % mod == 0:
-                logging.info(f"{done_pairs}/{num_pairs} ({done_pairs/num_pairs:.2%})")
+                logging.info(
+                    "%d/%d (%.2f%%)",
+                    done_pairs,
+                    num_pairs,
+                    done_pairs / num_pairs * 100,
+                )
 
         ref_edges = bs_comparison.generate_edges(
             ref_to_ref_bin, run.comparison.alignment_mode, run.cores, callback

--- a/big_scape/enums/__init__.py
+++ b/big_scape/enums/__init__.py
@@ -1,12 +1,15 @@
 """Module containing code related to enums"""
-
+from .input_parameters import INPUT_MODE
 from .source_type import SOURCE_TYPE
 from .partial_task import TASK, INPUT_TASK, HMM_TASK, COMPARISON_TASK
+from .comparison import ALIGNMENT_MODE
 
 __all__ = [
+    "INPUT_MODE",
     "SOURCE_TYPE",
     "TASK",
     "INPUT_TASK",
     "HMM_TASK",
     "COMPARISON_TASK",
+    "ALIGNMENT_MODE",
 ]

--- a/big_scape/enums/comparison.py
+++ b/big_scape/enums/comparison.py
@@ -1,0 +1,10 @@
+"""Enum for comparison types."""
+
+# from python
+from enum import Enum
+
+
+class ALIGNMENT_MODE(Enum):
+    GLOBAL = "global"
+    GLOCAL = "glocal"
+    AUTO = "auto"

--- a/big_scape/enums/input_parameters.py
+++ b/big_scape/enums/input_parameters.py
@@ -1,0 +1,9 @@
+"""Contains enums for input parameters."""
+
+# from python
+from enum import Enum
+
+
+class INPUT_MODE(Enum):
+    FLAT = "flat"
+    RECURSIVE = "recursive"

--- a/big_scape/errors/data.py
+++ b/big_scape/errors/data.py
@@ -6,7 +6,7 @@ class DBClosedError(Exception):
     or was never created in the first place
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(
             (
                 "Database was created before, but is closed now."
@@ -18,7 +18,7 @@ class DBClosedError(Exception):
 class DBAlreadyOpenError(Exception):
     """Error thrown when trying to open a database when a database is already open"""
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__("Database already opened!")
 
 

--- a/big_scape/errors/genbank.py
+++ b/big_scape/errors/genbank.py
@@ -4,7 +4,7 @@
 class InvalidGBKError(Exception):
     """Raised when a validation error occurs in parsing a GBK"""
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__("Validation error occurred when parsing a GeneBank file")
 
 
@@ -13,5 +13,5 @@ class InvalidGBKRegionChildError(Exception):
     qualifier
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__("GBK Feature is not parented correctly")

--- a/big_scape/file_input/__init__.py
+++ b/big_scape/file_input/__init__.py
@@ -4,6 +4,5 @@ from .load_files import load_dataset_folder, get_mibig, load_gbks
 __all__ = [
     "load_dataset_folder",
     "get_mibig",
-    "get_pfam",
     "load_gbks",
 ]

--- a/big_scape/file_input/load_files.py
+++ b/big_scape/file_input/load_files.py
@@ -96,7 +96,7 @@ def download_dataset(url: str, path: Path, path_compressed: Path) -> None:
 def load_dataset_folder(
     path: Path,
     source_type: bs_enums.SOURCE_TYPE,
-    mode: str = "recursive",
+    mode: bs_enums.INPUT_MODE = bs_enums.INPUT_MODE.RECURSIVE,
     include_gbk: Optional[List[str]] = None,
     exclude_gbk: Optional[List[str]] = None,
     cds_overlap_cutoff: Optional[float] = None,
@@ -122,10 +122,10 @@ def load_dataset_folder(
         logging.error("Dataset folder does not point to a directory!")
         raise NotADirectoryError()
 
-    if mode == "recursive":
+    if mode == bs_enums.INPUT_MODE.RECURSIVE:
         files = list(path.glob("**/*.gbk"))
 
-    if mode == "flat":
+    if mode == bs_enums.INPUT_MODE.FLAT:
         files = list(path.glob("*.gbk"))
 
     # empty folder?

--- a/big_scape/file_input/load_files.py
+++ b/big_scape/file_input/load_files.py
@@ -35,7 +35,8 @@ def get_mibig(mibig_version: str, bigscape_dir: Path):
         Path: path to MIBiG database (antismash processed gbks)
     """
 
-    mibig_url = f"https://dl.secondarymetabolites.org/mibig/mibig_antismash_{mibig_version}_gbk.tar.bz2"
+    mibig_url_base = "https://dl.secondarymetabolites.org/mibig/"
+    mibig_url = mibig_url_base + f"mibig_antismash_{mibig_version}_gbk.tar.bz2"
     # TODO: this only works for 3.1, update to proper link once Kai makes it available
     # https://dl.secondarymetabolites.org/mibig/mibig_antismash_3.1_gbk.tar.bz2
     # https://dl.secondarymetabolites.org/mibig/mibig_antismash_3.1_json.tar.bz2
@@ -77,19 +78,19 @@ def download_dataset(url: str, path: Path, path_compressed: Path) -> None:
     """
 
     # download
-    response = requests.get(url, stream=True)
+    response = requests.get(url, stream=True, timeout=10)
+
     if response.status_code != 200:
         raise ValueError("Could not download MIBiG file")
-    with open(path_compressed, "wb") as f:
-        f.write(response.raw.read())
+
+    with open(path_compressed, "wb") as file:
+        file.write(response.raw.read())
 
     # extract contents
-    file = tarfile.open(path_compressed)
-    file.extractall(path)
-    file.close()
-    os.remove(path_compressed)
+    with tarfile.open(path_compressed) as file:
+        file.extractall(path)
 
-    return None
+    os.remove(path_compressed)
 
 
 def load_dataset_folder(
@@ -103,13 +104,11 @@ def load_dataset_folder(
 ) -> List[GBK]:
     """Loads all gbk files in a given folder
 
-    Returns empty list if path does not point to a folder or if folder does not contain gbk files
+    Returns empty list if path does not point to a folder or if folder does not contain
+    gbk files
     """
 
-    if (
-        source_type == bs_enums.SOURCE_TYPE.QUERY
-        or source_type == bs_enums.SOURCE_TYPE.REFERENCE
-    ):
+    if source_type in (bs_enums.SOURCE_TYPE.QUERY, bs_enums.SOURCE_TYPE.REFERENCE):
         if not include_gbk:
             include_gbk = ["cluster", "region"]
 
@@ -137,12 +136,12 @@ def load_dataset_folder(
     filtered_files = filter_files(files, include_gbk, exclude_gbk)
     num_files = len(filtered_files)
 
-    logging.info(f"Loading {num_files} GBKs")
+    logging.info("Loading %d GBKs", num_files)
 
     gbk_list = []
     for idx, file in enumerate(filtered_files):
         if num_files > 9 and idx % floor(num_files / 10) == 0:
-            logging.info(f"Loaded {idx}/{num_files} GBKs")
+            logging.info("Loaded %d/%d GBKs", idx, num_files)
 
         gbk = load_gbk(file, source_type, cds_overlap_cutoff, legacy_mode)
 
@@ -203,7 +202,8 @@ def load_gbk(
 
     Args:
         path (Path): path to gbk file
-        source_type (bs_enums.SOURCE_TYPE): str, type of gbk file (query, mibig, reference)
+        source_type (bs_enums.SOURCE_TYPE): str, type of gbk file (query, mibig,
+            reference)
         cds_overlap_cutoff (Optional[float]): cds region overlap cutoff to use.
         Defaults to None
 
@@ -222,8 +222,18 @@ def load_gbk(
 
 
 def load_gbks(run: bs_param.RunParameters, bigscape_dir: Path) -> list[GBK]:
-    # counterintuitive, but we need to load the gbks first to see if there are any differences with
-    # the data in the database
+    """Load all gbks from the input folder and return a list of GBK objects
+
+    Args:
+        run (bs_param.RunParameters): run parameters
+        bigscape_dir (Path): path to BiG-SCAPE directory
+
+    Returns:
+        list[GBK]: list of GBK objects
+    """
+
+    # counterintuitive, but we need to load the gbks first to see if there are any
+    # differences with the data in the database
 
     input_gbks = []
 

--- a/big_scape/genbank/bgc_record.py
+++ b/big_scape/genbank/bgc_record.py
@@ -273,11 +273,12 @@ class BGCRecord:
         if "other" not in products:
             return ".".join(products)
 
-        # in all other cases we have an 'other' classification. for the rest of the cases we can remove
-        # that and just parse the products again
+        # in all other cases we have an 'other' classification. for the rest of the
+        # cases we can remove that and just parse the products again
         products.remove("other")
         return BGCRecord.parse_products(products)
 
+    @staticmethod
     def parse_common(
         feature: SeqFeature,
     ) -> tuple[int, int, Optional[bool], str]:
@@ -301,10 +302,7 @@ class BGCRecord:
         if "contig_edge" in feature.qualifiers:
             contig_edge_qualifier = feature.qualifiers["contig_edge"][0]
 
-            if contig_edge_qualifier == "True":
-                contig_edge = True
-            else:
-                contig_edge = False
+            contig_edge = contig_edge_qualifier == "True"
 
         if "product" not in feature.qualifiers:
             logging.error("product qualifier not found in feature!")

--- a/big_scape/genbank/bgc_record.py
+++ b/big_scape/genbank/bgc_record.py
@@ -190,6 +190,9 @@ class BGCRecord:
             query. Defaults to True.
         """
 
+        if not DB.metadata:
+            raise RuntimeError("DB.metadata is None")
+
         bgc_record_table = DB.metadata.tables["bgc_record"]
 
         contig_edge = None
@@ -221,6 +224,10 @@ class BGCRecord:
 
         # get return value
         return_row = cursor_result.fetchone()
+
+        if return_row is None:
+            raise RuntimeError("No return value from insert query")
+
         self._db_id = return_row[0]
 
         if commit:

--- a/big_scape/genbank/candidate_cluster.py
+++ b/big_scape/genbank/candidate_cluster.py
@@ -166,6 +166,10 @@ class CandidateCluster(BGCRecord):
             region_dict (dict[int, Region]): Dictionary of Region objects with database
             ids as keys. Used for reassembling the hierarchy
         """
+
+        if not DB.metadata:
+            raise RuntimeError("DB.metadata is None")
+
         record_table = DB.metadata.tables["bgc_record"]
 
         candidate_cluster_select_query = (

--- a/big_scape/genbank/cds.py
+++ b/big_scape/genbank/cds.py
@@ -153,6 +153,10 @@ class CDS:
 
         # get return value
         return_row = cursor_result.fetchone()
+
+        if return_row is None:
+            raise RuntimeError("No return value from insert query")
+
         self._db_id = return_row[0]
 
         # only now that we have handled the return we can commit
@@ -331,6 +335,10 @@ class CDS:
             region_dict (dict[int, GBK]): Dictionary of Region objects with database ids
             as keys. Used for parenting
         """
+
+        if not DB.metadata:
+            raise RuntimeError("DB.metadata is None")
+
         cds_table = DB.metadata.tables["cds"]
 
         region_select_query = (

--- a/big_scape/genbank/cds.py
+++ b/big_scape/genbank/cds.py
@@ -46,7 +46,6 @@ class CDS:
         self.strand: Optional[int] = None
         self.aa_seq: str = ""
         self.hsps: list[HSP] = []
-        self.__locked = False
 
         # db specific fields
         self._db_id: Optional[int] = None
@@ -159,13 +158,6 @@ class CDS:
         # only now that we have handled the return we can commit
         if commit:
             DB.commit()
-
-    def lock(self):
-        """Locks this CDS, converting the sorted list of HSPs to a regular list to support pickling
-        TOOD: remove once sortedlists are removed
-        """
-        self.__locked = True
-        self.hsps = list(self.hsps)
 
     def __eq__(self, __o) -> bool:
         if not isinstance(__o, CDS):

--- a/big_scape/genbank/gbk.py
+++ b/big_scape/genbank/gbk.py
@@ -147,6 +147,10 @@ class GBK:
 
         Arguments:
             commit: commit immediately after executing the insert query"""
+
+        if not DB.metadata:
+            raise RuntimeError("DB.metadata is None")
+
         gbk_table = DB.metadata.tables["gbk"]
         insert_query = (
             gbk_table.insert()
@@ -167,6 +171,10 @@ class GBK:
 
         # get return value
         return_row = cursor_result.fetchone()
+
+        if return_row is None:
+            raise RuntimeError("No return value from insert query")
+
         self._db_id = return_row[0]
 
         # only now that we have handled the return we can commit
@@ -192,6 +200,10 @@ class GBK:
         Returns:
             list[GBK]: _description_
         """
+
+        if not DB.metadata:
+            raise RuntimeError("DB.metadata is None")
+
         gbk_table = DB.metadata.tables["gbk"]
 
         select_query = (
@@ -235,6 +247,9 @@ class GBK:
             GBK: loaded GBK object
         """
 
+        if not DB.metadata:
+            raise RuntimeError("DB.metadata is None")
+
         gbk_table = DB.metadata.tables["gbk"]
         select_query = (
             gbk_table.select()
@@ -249,6 +264,9 @@ class GBK:
         )
 
         result = DB.execute(select_query).fetchone()
+
+        if result is None:
+            raise RuntimeError(f"No GBK with id {gbk_id}")
 
         new_gbk = GBK(Path(result.path), result.source_type)
         new_gbk._db_id = result.id
@@ -266,6 +284,9 @@ class GBK:
         Returns:
             list[GBK]: loaded GBK objects
         """
+
+        if not DB.metadata:
+            raise RuntimeError("DB.metadata is None")
 
         gbk_table = DB.metadata.tables["gbk"]
         select_query = (

--- a/big_scape/genbank/gbk.py
+++ b/big_scape/genbank/gbk.py
@@ -244,6 +244,7 @@ class GBK:
                 gbk_table.c.source_type,
                 gbk_table.c.nt_seq,
             )
+            .where(gbk_table.c.id == gbk_id)
             .compile()
         )
 
@@ -363,7 +364,8 @@ class GBK:
         cds_overlap_cutoff: Optional[float] = None,
         legacy_mode=False,
     ) -> None:
-        """Parses a GBK record of AS version 4 and returns a GBK object with all necessary information
+        """Parses a GBK record of AS version 4 and returns a GBK object with all
+        necessary information
 
         Args:
             record (SeqRecord): gbk file record
@@ -409,7 +411,8 @@ class GBK:
         cds_overlap_cutoff: Optional[float] = None,
         legacy_mode=False,
     ) -> None:
-        """Parses a GBK record of AS versions 5 and up and returns a GBK object with all necessary information
+        """Parses a GBK record of AS versions 5 and up and returns a GBK object with all
+        necessary information
 
         Args:
             record (SeqRecord): gbk file record

--- a/big_scape/genbank/proto_cluster.py
+++ b/big_scape/genbank/proto_cluster.py
@@ -158,6 +158,10 @@ class ProtoCluster(BGCRecord):
             candidate_cluster_dict (dict[int, GBK]): Dictionary of CandidateCluster
             objects with database ids as keys. Used for reassembling the hierarchy
         """
+
+        if not DB.metadata:
+            raise RuntimeError("DB.metadata is None")
+
         record_table = DB.metadata.tables["bgc_record"]
 
         protocluster_select_query = (

--- a/big_scape/genbank/proto_core.py
+++ b/big_scape/genbank/proto_core.py
@@ -112,6 +112,10 @@ class ProtoCore(BGCRecord):
             region_dict (dict[int, GBK]): Dictionary of Region objects with database ids
             as keys. Used for parenting
         """
+
+        if not DB.metadata:
+            raise RuntimeError("DB.metadata is None")
+
         record_table = DB.metadata.tables["bgc_record"]
 
         region_select_query = (

--- a/big_scape/genbank/region.py
+++ b/big_scape/genbank/region.py
@@ -82,7 +82,9 @@ class Region(BGCRecord):
         super().save_record("region", commit)
 
     def save_all(self) -> None:
-        """Stores this Region and its children in the database. Does not commit immediately"""
+        """Stores this Region and its children in the database. Does not commit
+        immediately
+        """
         self.save(False)
         for candidate_cluster in self.cand_clusters.values():
             if candidate_cluster is None:
@@ -133,15 +135,15 @@ class Region(BGCRecord):
 
         if "candidate_cluster_numbers" not in feature.qualifiers:
             if parent_gbk is not None and parent_gbk.source_type == SOURCE_TYPE.MIBIG:
-                # we know that MIBiG BGCs, although processed with versions of AS7 and above,
-                # dont always have features beyond region
+                # we know that MIBiG BGCs, although processed with versions of AS7 and
+                # above dont always have features beyond region
                 return region
-            else:
-                logging.warning(
-                    "candidate_cluster_numbers qualifier not found in region feature!"
-                    "consider checking whether there is something special about this gbk"
-                )
-                raise InvalidGBKError()
+
+            logging.warning(
+                "candidate_cluster_numbers qualifier not found in region feature!"
+                "consider checking whether there is something special about this gbk"
+            )
+            raise InvalidGBKError()
 
         cand_clusters: dict[int, Optional[CandidateCluster]] = {}
         for cand_cluster_number in feature.qualifiers["candidate_cluster_numbers"]:
@@ -201,10 +203,6 @@ class Region(BGCRecord):
 
     def get_cds_with_domains(self, return_all=True, reverse=False) -> list[CDS]:
         return super().get_cds_with_domains(return_all, reverse)
-
-    def get_attr_dict(self) -> dict[str, object]:
-        """Gets a dictionary of attributes, useful for adding to network nodes later"""
-        return super().get_attr_dict()
 
     def __repr__(self):
         return f"{self.parent_gbk} Region {self.number} {self.nt_start}-{self.nt_stop} "

--- a/big_scape/genbank/region.py
+++ b/big_scape/genbank/region.py
@@ -218,6 +218,10 @@ class Region(BGCRecord):
             gbk_dict (dict[int, GBK]): Dictionary of GBK objects with database ids as
             keys. Used for reassembling the hierarchy
         """
+
+        if not DB.metadata:
+            raise RuntimeError("DB.metadata is None")
+
         record_table = DB.metadata.tables["bgc_record"]
 
         region_select_query = (

--- a/big_scape/hmm/__init__.py
+++ b/big_scape/hmm/__init__.py
@@ -1,5 +1,5 @@
 """Contains code to execute hmmpress, hmmscan and hmmalign"""
-from .hmmer import HMMer
+from .hmmer import HMMer  # type: ignore
 from .hsp import HSP, HSPAlignment
 from .legacy_filter import legacy_filter_overlap
 

--- a/big_scape/hmm/hmmer.py
+++ b/big_scape/hmm/hmmer.py
@@ -1,4 +1,5 @@
-"""Contains methods to press an input .hmm file into more optimal formats for hmmscan and hmmalign
+"""Contains methods to press an input .hmm file into more optimal formats for hmmscan
+and hmmalign
 """
 
 # from python
@@ -34,6 +35,8 @@ if TYPE_CHECKING:  # pragma: no cover
 
 
 class HMMer:
+    """Class to handle HMMer related tasks"""
+
     pipeline: Pipeline = None
     profiles: list[OptimizedProfile]
     profile_index: dict[str, int]
@@ -56,7 +59,7 @@ class HMMer:
             hmm_path.parent / (hmm_path.name + expected_extension)
             for expected_extension in expected_extensions
         ]
-        return all([path.exists() for path in expected_paths])
+        return all((path.exists() for path in expected_paths))
 
     @staticmethod
     def press(hmm_path: Path) -> None:
@@ -88,7 +91,7 @@ class HMMer:
             exist. Defaults to True.
         """
         logging.info("Reading HMM Profiles")
-        HMMer.profiles = list()
+        HMMer.profiles = []
         with HMMFile(hmm_path) as hmm_file:
             if optimized:
                 logging.debug("Loading optimized profiles")
@@ -116,7 +119,7 @@ class HMMer:
         init() again for hmmalign
         """
         logging.info("Unloading profiles")
-        HMMer.profiles = list()
+        HMMer.profiles = []
         HMMer.profile_index = {}
         HMMer.pipeline = None
 
@@ -198,10 +201,10 @@ class HMMer:
             # name is actually the list index of the original CDS
             sequences.append(TextSequence(name=str(idx).encode(), sequence=cds.aa_seq))
 
-        ds = TextSequenceBlock(sequences).digitize(HMMer.alphabet)
+        digital_sequence = TextSequenceBlock(sequences).digitize(HMMer.alphabet)
 
         for top_hits in hmmsearch(
-            HMMer.profiles, ds, bit_cutoffs="trusted", cpus=cores
+            HMMer.profiles, digital_sequence, bit_cutoffs="trusted", cpus=cores
         ):
             for hit in top_hits:
                 if not hit.included:

--- a/big_scape/hmm/hmmer.py
+++ b/big_scape/hmm/hmmer.py
@@ -1,3 +1,4 @@
+# type: ignore # mypy doesn't like pyhmmer
 """Contains methods to press an input .hmm file into more optimal formats for hmmscan
 and hmmalign
 """

--- a/big_scape/hmm/hsp.py
+++ b/big_scape/hmm/hsp.py
@@ -4,9 +4,6 @@
 from __future__ import annotations
 from typing import Optional, TYPE_CHECKING
 
-# from dependencies
-from pyhmmer.plan7 import Domain
-
 # from other modules
 from big_scape.data import DB
 
@@ -20,7 +17,7 @@ class HSP:
     """Describes a CDS - Domain relationship"""
 
     def __init__(
-        self, cds: CDS, domain: Domain, score: float, env_start: int, env_stop: int
+        self, cds: CDS, domain: str, score: float, env_start: int, env_stop: int
     ) -> None:
         self.cds = cds
         self.domain = domain
@@ -44,6 +41,9 @@ class HSP:
         if self.cds is not None and self.cds._db_id is not None:
             parent_cds_id = self.cds._db_id
 
+        if not DB.metadata:
+            raise RuntimeError("DB.metadata is None")
+
         hsp_table = DB.metadata.tables["hsp"]
         insert_query = (
             hsp_table.insert()
@@ -65,6 +65,10 @@ class HSP:
 
         # get return value
         return_row = cursor_result.fetchone()
+
+        if return_row is None:
+            raise RuntimeError("No return value from insert query")
+
         self._db_id = return_row[0]
 
         # only now that we have handled the return we can commit
@@ -130,6 +134,9 @@ class HSP:
             to populate with HSP objects from the database
         """
         cds_dict = {cds._db_id: cds for cds in cds_list}
+
+        if not DB.metadata:
+            raise RuntimeError("DB.metadata is None")
 
         hsp_table = DB.metadata.tables["hsp"]
         hsp_alignment_table = DB.metadata.tables["hsp_alignment"]
@@ -280,6 +287,9 @@ class HSPAlignment:
         parent_hsp_id = None
         if self.hsp is not None and self.hsp._db_id is not None:
             parent_hsp_id = self.hsp._db_id
+
+        if not DB.metadata:
+            raise RuntimeError("DB.metadata is None")
 
         hsp_align_table = DB.metadata.tables["hsp_alignment"]
         insert_query = hsp_align_table.insert().values(

--- a/big_scape/main.py
+++ b/big_scape/main.py
@@ -1,3 +1,5 @@
+"""Main file for bigscape"""
+
 # from python
 import sys
 import os
@@ -29,7 +31,10 @@ import big_scape.distances.mix as bs_mix
 import big_scape.distances.query as bs_query
 
 
-def run_bigscape():
+def run_bigscape() -> None:
+    """Run a bigscape analysis. This is the main function of the program that parses the
+    command line arguments, loads the data, runs the analysis and saves the output.
+    """
     bigscape_dir = Path(os.path.dirname(os.path.abspath(__file__)))
 
     # parsing needs to come first because we need it in setting up the logging
@@ -63,7 +68,7 @@ def run_bigscape():
     # nothing to do!
     if run_state == bs_enums.TASK.NOTHING_TO_DO:
         logging.info("Nothing to do!")
-        exit(0)
+        sys.exit(0)
 
     logging.info("First task: %s", run_state)
 

--- a/big_scape/network/families.py
+++ b/big_scape/network/families.py
@@ -81,14 +81,14 @@ def aff_sim_matrix(matrix):
     # thanks numpy but we sort of know what we're doing
     warnings.filterwarnings(action="ignore", category=ConvergenceWarning)
 
-    af = AffinityPropagation(
+    af_results = AffinityPropagation(
         damping=0.9,
         max_iter=1000,
         convergence_iter=200,
         affinity="precomputed",
     ).fit(matrix)
 
-    return af.labels_, af.cluster_centers_indices_
+    return af_results.labels_, af_results.cluster_centers_indices_
 
 
 def save_to_db(regions_families):

--- a/big_scape/network/network.py
+++ b/big_scape/network/network.py
@@ -2,7 +2,7 @@
 
 
 # from dependencies
-from typing import Optional, Generator
+from typing import Optional, Generator, cast
 from sqlalchemy import tuple_
 
 # from other modules
@@ -72,13 +72,17 @@ def get_connected_components(
 def get_edge(
     exclude_nodes: set[int],
     cutoff: Optional[float] = None,
-) -> tuple[int, int, float, float, float, float]:
+) -> Optional[tuple[int, int, float, float, float, float]]:
     """Get an edge from the database that is not connected to exclude_nodes"""
 
     if cutoff is None:
         cutoff = 1.0
 
     # fetch an edge from the database
+
+    if not DB.metadata:
+        raise RuntimeError("DB.metadata is None")
+
     select_statment = (
         DB.metadata.tables["distance"]
         .select()
@@ -89,7 +93,10 @@ def get_edge(
 
     edge = DB.execute(select_statment).fetchone()
 
-    return edge
+    if edge is None:
+        return None
+
+    return cast(tuple[int, int, float, float, float, float], edge)
 
 
 def get_edges(
@@ -100,6 +107,10 @@ def get_edges(
         distance_cutoff = 1.0
 
     # fetch edges from the database
+
+    if not DB.metadata:
+        raise RuntimeError("DB.metadata is None")
+
     distance_table = DB.metadata.tables["distance"]
     select_statement = (
         distance_table.select()
@@ -114,7 +125,7 @@ def get_edges(
 
     edges = DB.execute(select_statement).fetchall()
 
-    return edges
+    return cast(list[tuple[int, int, float, float, float, float]], edges)
 
 
 def get_connected_edges(
@@ -127,6 +138,10 @@ def get_connected_edges(
         distance_cutoff = 1.0
 
     # fetch edges from the database
+
+    if not DB.metadata:
+        raise RuntimeError("DB.metadata is None")
+
     distance_table = DB.metadata.tables["distance"]
     select_statement = (
         distance_table.select()
@@ -152,4 +167,4 @@ def get_connected_edges(
 
     edges = DB.execute(select_statement).fetchall()
 
-    return edges
+    return cast(list[tuple[int, int, float, float, float, float]], edges)

--- a/big_scape/network/utility.py
+++ b/big_scape/network/utility.py
@@ -36,10 +36,10 @@ def edge_list_to_adj_list(
         dict[int, dict[int, float]]: adjacency list
     """
     # set up the dictionary of dictionaries
-    adj_list: dict[int, dict[int, float]] = dict()
+    adj_list: dict[int, dict[int, float]] = {}
     for edge in edge_list:
-        adj_list[edge[0]] = dict()
-        adj_list[edge[1]] = dict()
+        adj_list[edge[0]] = {}
+        adj_list[edge[1]] = {}
 
     # go through all edges
     for region_a, region_b, distance, _, _, _ in edge_list:
@@ -81,7 +81,7 @@ def adj_list_to_sim_matrix(adj_list: dict[int, dict[int, float]]) -> np.ndarray:
     matrix = np.zeros((len(adj_list), len(adj_list)))
 
     # set up a dictionary to map region ids to matrix indices
-    region_to_index = dict()
+    region_to_index = {}
     for index, region in enumerate(adj_list):
         region_to_index[region] = index
 

--- a/big_scape/output/legacy_output.py
+++ b/big_scape/output/legacy_output.py
@@ -688,6 +688,9 @@ def generate_bs_families_members(
     # get a dictionary of node id to family id
     node_family = {}
 
+    if not DB.metadata:
+        raise RuntimeError("DB.metadata is None")
+
     # get all families from the database
     bgc_families_table = DB.metadata.tables["bgc_record_family"]
 

--- a/big_scape/parameters/__init__.py
+++ b/big_scape/parameters/__init__.py
@@ -1,8 +1,8 @@
 """Contains modules for parameters, both user input and constants"""
 from .run import RunParameters
-from .input import InputParameters, INPUT_MODE
+from .input import InputParameters
 from .output import OutputParameters
-from .comparison import ComparisonParameters, ALIGNMENT_MODE
+from .comparison import ComparisonParameters
 from .diagnostics import DiagnosticsParameters
 from .hmmer import HmmerParameters
 from .binning import BinningParameters
@@ -12,11 +12,9 @@ from .cmd_parser import parse_cmd
 __all__ = [
     "RunParameters",
     "InputParameters",
-    "INPUT_MODE",
     "HmmerParameters",
     "BinningParameters",
     "ComparisonParameters",
-    "ALIGNMENT_MODE",
     "NetworkingParameters",
     "DiagnosticsParameters",
     "OutputParameters",

--- a/big_scape/parameters/binning.py
+++ b/big_scape/parameters/binning.py
@@ -19,13 +19,13 @@ class BinningParameters:
         query_bgc_path: Optional[Path]
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.no_mix: bool = False
         self.legacy_classify: bool = False
         self.classify: bool = False
         self.query_bgc_path: Optional[Path] = None
 
-    def validate(self):
+    def validate(self) -> None:
         """Validate the arguments contained in this object and set default values"""
         validate_mix(self.no_mix)
         validate_legacy_classify(self.legacy_classify)
@@ -33,7 +33,7 @@ class BinningParameters:
 
         self.validate_work()
 
-    def validate_work(self):
+    def validate_work(self) -> None:
         """Raise an error if the combination of parameters in this object means no work
         will be done
         """
@@ -67,7 +67,7 @@ class BinningParameters:
             raise InvalidArgumentError("--query_bgc_path", self.query_bgc_path)
 
 
-def validate_mix(no_mix: bool):
+def validate_mix(no_mix: bool) -> None:
     """Validates the no_mix attribute. Raises an exception if it is set to none, which
     should never happen
     """
@@ -82,7 +82,7 @@ def validate_mix(no_mix: bool):
         raise InvalidArgumentError("--no_mix", no_mix)
 
 
-def validate_legacy_classify(legacy_classify: bool):
+def validate_legacy_classify(legacy_classify: bool) -> None:
     """Validates the legacy_classify attribute. Raises an exception if it is set to
     none, which should never happen
     """
@@ -97,7 +97,7 @@ def validate_legacy_classify(legacy_classify: bool):
         raise InvalidArgumentError("--legacy_classify", legacy_classify)
 
 
-def validate_classify(classify: bool):
+def validate_classify(classify: bool) -> None:
     """Validates the classify attribute. Raises an exception if it is set to none, which
     should never happen
     """
@@ -112,17 +112,20 @@ def validate_classify(classify: bool):
         raise InvalidArgumentError("--classify", classify)
 
 
-def validate_query_bgc(query_bgc_path: Path):
+def validate_query_bgc(query_bgc_path: Optional[Path]) -> None:
     """Raises an InvalidArgumentError if the query bgc path does not exist"""
 
-    if query_bgc_path and not query_bgc_path.exists():
+    if not query_bgc_path:
+        return
+
+    if not query_bgc_path.exists():
         logging.error("Query BGC path does not exist!")
         raise InvalidArgumentError("--query_bgc_path", query_bgc_path)
 
-    if query_bgc_path and not query_bgc_path.is_file():
+    if not query_bgc_path.is_file():
         logging.error("Query BGC path is not a file!")
         raise InvalidArgumentError("--query_bgc_path", query_bgc_path)
 
-    if query_bgc_path and query_bgc_path.suffix != ".gbk":
+    if query_bgc_path.suffix != ".gbk":
         logging.error("Query BGC path is not a .gbk file!")
         raise InvalidArgumentError("--query_bgc_path", query_bgc_path)

--- a/big_scape/parameters/binning.py
+++ b/big_scape/parameters/binning.py
@@ -34,7 +34,9 @@ class BinningParameters:
         self.validate_work()
 
     def validate_work(self):
-        """Raise an error if the combination of parameters in this object means no work will be done"""
+        """Raise an error if the combination of parameters in this object means no work
+        will be done
+        """
 
         if (
             self.no_mix is True
@@ -50,7 +52,8 @@ class BinningParameters:
             )
             raise InvalidArgumentError("--no_mix", self.no_mix)
 
-        # TODO: legacy_no_classify needs to be changed to legacy_classify, and add argument to no_classify
+        # TODO: legacy_no_classify needs to be changed to legacy_classify, and add
+        # argument to no_classify
         if self.query_bgc_path is not None and (
             self.legacy_classify is True or self.no_mix is True or self.classify is True
         ):
@@ -80,6 +83,9 @@ def validate_mix(no_mix: bool):
 
 
 def validate_legacy_classify(legacy_classify: bool):
+    """Validates the legacy_classify attribute. Raises an exception if it is set to
+    none, which should never happen
+    """
     if legacy_classify is None:
         logging.error(
             (
@@ -92,6 +98,9 @@ def validate_legacy_classify(legacy_classify: bool):
 
 
 def validate_classify(classify: bool):
+    """Validates the classify attribute. Raises an exception if it is set to none, which
+    should never happen
+    """
     if classify is None:
         logging.error(
             (

--- a/big_scape/parameters/cmd_parser.py
+++ b/big_scape/parameters/cmd_parser.py
@@ -92,8 +92,9 @@ def parse_cmd(args):  # pragma: no cover
         type=str,
         choices=["1.0", "1.1", "1.2", "1.3", "1.4", "2.0", "3.0", "3.1"],
         # TODO: get rid of hardcoded versions?
-        help="MIBiG relase number (e.g. 3.1). Download (if needed) and use this version of MiBIG database. \
-            If not provided, MiBIG will not be included in the analysis. If download is required, BiG-SCAPE\
+        help="MIBiG relase number (e.g. 3.1). Download (if needed) and use this \
+            version of MiBIG database. If not provided, MiBIG will not be included in \
+            the analysis. If download is required, BiG-SCAPE \
             will download the MIBiG database to the BiG-SCAPE folder",
     )
 

--- a/big_scape/parameters/comparison.py
+++ b/big_scape/parameters/comparison.py
@@ -1,17 +1,10 @@
 """Module containing a class for a BiG-SCAPE comparison object, which has all the
 comparison parameters/arguments"""
 
-# from python
-from enum import Enum
-
 # from other modules
 from big_scape.errors import InvalidArgumentError
 
-
-class ALIGNMENT_MODE(Enum):
-    GLOBAL = "global"
-    GLOCAL = "glocal"
-    AUTO = "auto"
+import big_scape.enums as bs_enums
 
 
 class ComparisonParameters:
@@ -23,18 +16,18 @@ class ComparisonParameters:
         #TODO: proto/refion, similarity filters, distance calc modes, weights
     """
 
-    def __init__(self):
-        self.alignment_mode: ALIGNMENT_MODE = ALIGNMENT_MODE.AUTO
+    def __init__(self) -> None:
+        self.alignment_mode: bs_enums.ALIGNMENT_MODE = bs_enums.ALIGNMENT_MODE.AUTO
 
     def validate(self):
         """Validate the arguments contained in this object and set default values"""
         validate_alignment_mode(self.alignment_mode)
 
 
-def validate_alignment_mode(alignment_mode):
+def validate_alignment_mode(alignment_mode) -> None:
     """Validate the passed alignment mode is one of the allowed modes"""
     # this should not ever run so long as the choices in the cmd_parser
     # remain updated and relevant
-    valid_modes = [mode.value for mode in ALIGNMENT_MODE]
+    valid_modes = [mode.value for mode in bs_enums.ALIGNMENT_MODE]
     if alignment_mode not in valid_modes:
         raise InvalidArgumentError("--align_mode", alignment_mode)

--- a/big_scape/parameters/hmmer.py
+++ b/big_scape/parameters/hmmer.py
@@ -26,23 +26,27 @@ class HmmerParameters:
         domain_includelist_path: Optional[Path]
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.force_hmmscan: bool = False
         self.skip_hmmscan: bool = False
         self.domain_overlap_cutoff: float = 1.0
         self.domain_includelist_path: Optional[Path] = None
 
         # not from arguments:
-        self.domain_includelist = []
+        self.domain_includelist: list[str] = []
 
-    def validate(self, run: RunParameters):
+    def validate(self, run: RunParameters) -> None:
         """Performs validation on this class parameters"""
         validate_hsp_overlap_cutoff(self.domain_overlap_cutoff)
-        self.domain_includelist = validate_includelist(self.domain_includelist_path)
+
+        validated_includelist = validate_includelist(self.domain_includelist_path)
+        if validated_includelist is not None:
+            self.domain_includelist = validated_includelist
+
         validate_skip_hmmscan(self.skip_hmmscan, run.output.output_dir)
 
 
-def validate_skip_hmmscan(skip_hmmscan: bool, output_dir: Path):
+def validate_skip_hmmscan(skip_hmmscan: bool, output_dir: Path) -> None:
     """Validates whether an output directory exists and is not empty when running
     skip_hmm, which requires already processed gbk files and hance a DB in output"""
 
@@ -65,7 +69,7 @@ def validate_skip_hmmscan(skip_hmmscan: bool, output_dir: Path):
 
 def validate_includelist(
     domain_includelist_path: Optional[Path],
-):
+) -> Optional[list[str]]:
     """Validate the path to the domain include list and return a list of domain
     accession strings contained within this file
 
@@ -103,7 +107,7 @@ def validate_includelist(
         return lines
 
 
-def validate_hsp_overlap_cutoff(cutoff: float):
+def validate_hsp_overlap_cutoff(cutoff: float) -> None:
     """Raises an InvalidArgumentError if cutoff is not between 0.0 and 1.0"""
 
     if cutoff < 0.0 or cutoff > 1.0:

--- a/big_scape/parameters/networking.py
+++ b/big_scape/parameters/networking.py
@@ -16,7 +16,7 @@ class NetworkingParameters:
         #TODO: modes
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.gcf_cutoffs: list[float] = []
         self.include_singletons: bool = False
 
@@ -25,7 +25,7 @@ class NetworkingParameters:
         validate_gcf_cutoffs(self.gcf_cutoffs)
 
 
-def validate_gcf_cutoffs(gcf_cutoffs):
+def validate_gcf_cutoffs(gcf_cutoffs) -> None:
     """Raises an InvalidArgumentError if any cutoff is lower than 0"""
     for cutoff in gcf_cutoffs:
         if cutoff < 0:

--- a/big_scape/parameters/output.py
+++ b/big_scape/parameters/output.py
@@ -21,13 +21,13 @@ class OutputParameters:
 
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.output_dir: Path = Path("")
         self.db_path: Path = Path("")
         self.log_path: Path = Path("")
         self.profile_path: Path = Path("")
 
-    def validate(self):
+    def validate(self) -> None:
         """Load output arguments from commandline ArgParser object
 
         Args:

--- a/big_scape/parameters/run.py
+++ b/big_scape/parameters/run.py
@@ -39,6 +39,7 @@ class RunParameters(Namespace):
     """
 
     def __init__(self):
+        super().__init__()
         self.label: str = "BiG-SCAPE"
         self.cores: int = cpu_count()
         self.legacy: bool = False

--- a/big_scape/parameters/run.py
+++ b/big_scape/parameters/run.py
@@ -38,7 +38,7 @@ class RunParameters(Namespace):
         output: parameters.OutputParameters
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.label: str = "BiG-SCAPE"
         self.cores: int = cpu_count()
@@ -64,7 +64,7 @@ class RunParameters(Namespace):
 
         return start_time
 
-    def validate(self):
+    def validate(self) -> None:
         """Executes validation on everything, setting default values and returning
         errors if anything is wrong
         Also initializes the logger
@@ -96,7 +96,7 @@ class RunParameters(Namespace):
     # this is called when argparser tries to add an attribute like "input.gbk_dir",
     # including the dot. this method ensures that instead a property will be added on
     # the input class instead
-    def __setattr__(self, name, value):
+    def __setattr__(self, name, value) -> None:
         if "." in name:
             group, name = name.split(".", 1)
             ns = getattr(self, group, RunParameters())

--- a/big_scape/utility/multiprocess.py
+++ b/big_scape/utility/multiprocess.py
@@ -5,6 +5,7 @@
 from multiprocessing import Process, Pipe
 from multiprocessing.connection import Connection
 from typing import Callable
+import logging
 
 
 def start_processes(
@@ -75,6 +76,8 @@ def worker_method(
         change while the worker is active
         use_batches (bool): True if this method uses batches, false if not
     """
+
+    logging.debug(f"Starting worker {process_id}")
 
     worker_connection.send(None)
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -13,3 +13,8 @@ anybadge
 
 # linting
 pylint
+
+# type stubs (https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports)
+types-psutil
+networkx-stubs
+data-science-types


### PR DESCRIPTION
Most issues are solved, except for when they're especially annoying.

Accomodating mypy also means introducing a whole bunch of None-checks where they are not needed. In particular, checks to see if DB.engine is None after already having done a DB.opened() check. Seems like Mypy is just not clever enough to figure that out.

example:

```python
        if not DB.opened():
            raise DBClosedError()

        if not DB.engine:
            raise RuntimeError("DB.engine is None")

        if not DB.connection:
            raise RuntimeError("DB.connection is None")
```

```DB.opened()``` already contains checks for both other if-statements. Understandable if mypy does not parse this, but annoying.