### PR TITLE
Hotfix/family assignments

### DIFF
--- a/big_scape/network/families.py
+++ b/big_scape/network/families.py
@@ -11,7 +11,7 @@ from sklearn.exceptions import ConvergenceWarning
 from big_scape.data import DB
 
 # from this module
-from .utility import edge_list_to_adj_list, adj_list_to_sim_matrix
+from .utility import edge_list_to_sim_matrix
 
 
 def generate_families(
@@ -43,13 +43,7 @@ def generate_families(
 
         return regions_families
 
-    adj_list = edge_list_to_adj_list(connected_component)
-
-    # this list is going to be in the same order as the distance matrix rows/col
-    # and the list of labels after AP
-    node_ids = list(adj_list.keys())
-
-    distance_matrix = adj_list_to_sim_matrix(adj_list)
+    distance_matrix, node_ids = edge_list_to_sim_matrix(connected_component)
 
     labels, centers = aff_sim_matrix(distance_matrix)
 

--- a/big_scape/network/utility.py
+++ b/big_scape/network/utility.py
@@ -93,3 +93,47 @@ def adj_list_to_sim_matrix(adj_list: dict[int, dict[int, float]]) -> np.ndarray:
             matrix[a_matrix_idx][b_matrix_idx] = 1 - adj_list[region_a][region_b]
 
     return matrix.tolist()
+
+
+def edge_list_to_sim_matrix(
+    edge_list: list[tuple[int, int, float, float, float, float, str]]
+) -> tuple[np.ndarray, list[int]]:
+    """Return a similarity matrix and id list from an edge list
+
+    This function returns an adjacency matrix, and a list where each element is the id
+    of a node at that index in the matrix
+
+    Args:
+        edge_list (list[tuple[int, int, float, float, float, float, str]]): list of edges
+
+    Returns:
+        tuple[np.ndarray, list[int]]: similarity matrix and list of region ids
+    """
+
+    # making sure this is correct by going through the edge list twice
+    # first time to get all the ids
+    id_to_idx: dict[int, int] = {}
+    idx_to_id: list[int] = []
+
+    for a_idx, b_idx, _, _, _, _, _ in edge_list:
+        if a_idx not in id_to_idx:
+            id_to_idx[a_idx] = len(id_to_idx)
+            idx_to_id.append(a_idx)
+        if b_idx not in id_to_idx:
+            id_to_idx[b_idx] = len(id_to_idx)
+            idx_to_id.append(b_idx)
+
+    # second time to fill in the matrix
+    matrix = np.zeros((len(id_to_idx), len(id_to_idx)))
+
+    for a_idx, b_idx, distance, _, _, _, _ in edge_list:
+        a_matrix_idx = id_to_idx[a_idx]
+        b_matrix_idx = id_to_idx[b_idx]
+        matrix[a_matrix_idx][b_matrix_idx] = 1 - distance
+        matrix[b_matrix_idx][a_matrix_idx] = 1 - distance
+
+    # self similarities
+    for i in range(len(matrix)):
+        matrix[i][i] = 1.0
+
+    return matrix, idx_to_id

--- a/big_scape/output/legacy_output.py
+++ b/big_scape/output/legacy_output.py
@@ -739,7 +739,11 @@ def generate_bs_families_members(
     for idx, record in enumerate(pair_generator.source_records):
         record_id = record._db_id
 
+        if record_id is None:
+            raise AttributeError("Record id is None!")
+
         if record_id not in node_family:
+            families_members[record_id] = [idx]
             continue
 
         family_id = node_family[record_id]

--- a/test/network/test_family.py
+++ b/test/network/test_family.py
@@ -12,9 +12,8 @@ class TestAffinityPropagation(TestCase):
     """Contains tests for affinity propagation"""
 
     @staticmethod
-    def gen_adj_list():
-        """Generates the adjacency list that is used in all tests under this test case"""
-        adj_list: dict[int, dict[int, float]] = {}
+    def gen_edge_list():
+        """Generates the edge list that is used in all tests under this test case"""
 
         # graph topology:
         # (numbers indicate distance)
@@ -35,9 +34,7 @@ class TestAffinityPropagation(TestCase):
             [3, 6],
         ]
 
-        for i in range(8):
-            adj_list[i] = {}
-            adj_list[i][i] = 0.0
+        edge_list = []
 
         for a, b in combinations(range(8), 2):
             same_cluster = (a in c1 and b in c1) or (a in c2 and b in c2)
@@ -50,16 +47,15 @@ class TestAffinityPropagation(TestCase):
                 # don't add other edges. this is after cutoff
                 continue
 
-            adj_list[a][b] = distance
-            adj_list[b][a] = distance
+            edge_list.append((a, b, distance, 0, 0, 0, ""))
 
-        return adj_list
+        return edge_list
 
     def test_sim_matrix_from_graph(self):
         """Tests whether sim_matrix_from_graph correctly generates a similarity matrix
         from a given graph using the given edge property
         """
-        adj_list = TestAffinityPropagation.gen_adj_list()
+        adj_list = TestAffinityPropagation.gen_edge_list()
 
         expected_sim_matrix = [
             [1.0, 0.99, 0.99, 0.99, 0.0, 0.0, 0.0, 0.0],
@@ -72,7 +68,9 @@ class TestAffinityPropagation(TestCase):
             [0.0, 0.0, 0.0, 0.0, 0.99, 0.99, 0.99, 1.0],
         ]
 
-        actual_sim_matrix = bs_families.adj_list_to_sim_matrix(adj_list)
+        actual_sim_matrix, _ = bs_families.edge_list_to_sim_matrix(adj_list)
+
+        actual_sim_matrix = actual_sim_matrix.tolist()
 
         # check if the matrices have the exact same values
         self.assertListEqual(expected_sim_matrix, actual_sim_matrix)
@@ -81,9 +79,9 @@ class TestAffinityPropagation(TestCase):
         """Tests whether affinity propagation is correctly executed on a similarity
         matrix
         """
-        adj_list = TestAffinityPropagation.gen_adj_list()
+        adj_list = TestAffinityPropagation.gen_edge_list()
 
-        sim_matrix = bs_families.adj_list_to_sim_matrix(adj_list)
+        sim_matrix, _ = bs_families.edge_list_to_sim_matrix(adj_list)
 
         expected_labels = [0, 0, 0, 0, 1, 1, 1, 1]
 


### PR DESCRIPTION
This fixes family assignments (as they are currently implemented, using the ID of the cluster center record in the database as family id) by setting family ids of singletons to the record id of that singleton.

Doing this fixes singletons not having any family, and also fixes incorrect family assignments.
