### PR TITLE
Fix setup.py packaging, making bigscape installable

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -1,0 +1,8 @@
+import sys
+from . import bigscape
+
+def main():
+    bigscape.main()
+
+if __name__ == "__main__":
+    main()

--- a/bigscape.py
+++ b/bigscape.py
@@ -2072,8 +2072,7 @@ def CMD_parser():
 
     return parser.parse_args()
 
-
-if __name__=="__main__":
+def main():
     options = CMD_parser()
     
     class bgc_data:
@@ -3344,4 +3343,6 @@ if __name__=="__main__":
     with open(os.path.join(log_folder, "runtimes.txt"), 'a') as timings_file:
         timings_file.write(runtime_string + "\n")
     print(runtime_string)
-    
+
+if __name__=="__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -12,17 +12,19 @@ def generate_package_data():
     data_files.append('anchor_domains.txt')
     data_files.append('domain_includelist.txt')
     data_files.append('domains_color_file.tsv')
-    package_data={'BiG-SCAPE': data_files}
+    package_data={'bigscape': data_files}
     return package_data
 
 setup(
-     name='BiG-SCAPE',
-     version='1.1.4',
+     name='bigscape',
+     version='1.1.5',
      py_modules=['functions','ArrowerSVG'],
-     packages=['BiG-SCAPE'],
-     package_dir={'BiG-SCAPE': '.'},
+     packages=['bigscape'],
+     package_dir={'bigscape': '.'},
      package_data=generate_package_data(),
-     scripts=['bigscape.py'],
+     entry_points={
+         'console_scripts': ['bigscape=bigscape.bigscape:main']
+     },
      description='Biosynthetic Genes Similarity Clustering and Prospecting Engine.',
      keywords=['secondary metabolites', 'natural products', 'genome mining'],
      url='https://github.com/medema-group/BiG-SCAPE',

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
      package_dir={'bigscape': '.'},
      package_data=generate_package_data(),
      entry_points={
-         'console_scripts': ['bigscape=bigscape.bigscape:main']
+         'console_scripts': ['bigscape=bigscape.__main__:main']
      },
      description='Biosynthetic Genes Similarity Clustering and Prospecting Engine.',
      keywords=['secondary metabolites', 'natural products', 'genome mining'],


### PR DESCRIPTION
In its current state, bigscape cannot be installed as a python package, because the script bigscape.py must be in the same directory as data files it depends on. Anyone trying to install it as a package gets a broken install, as seen by people reporting the broken bioconda distribution:

https://github.com/medema-group/BiG-SCAPE/issues/23
https://github.com/medema-group/BiG-SCAPE/issues/39

This PR updates setup.py so that bigscape can be packaged and installed with pip or conda. This should fix the bioconda distribution, as well as making installs of bigscape act predictably. It wraps the entry script in bigscape.py in a `main()` function, and uses `console_scripts` in setup.py to create an entrypoint that calls that main. This will result in bigscape.py staying next to the data it needs, inside the bigscape package.

This also updates the packages name when distributed to be `bigscape`, the current name is not importable. Python packages should have short, all-lowercase names, and cannot have dashes: https://peps.python.org/pep-0008/#package-and-module-names . 

There seems to be a lot of demand for a Bioconda distribution of bigscape. With these fixes in place, it should fix the Bioconda distribution and also make it easy to submit to PyPI as well, if you like.

