### PR TITLE
Feature/hybrids off

### DIFF
--- a/big_scape/cli/cli_common_options.py
+++ b/big_scape/cli/cli_common_options.py
@@ -275,6 +275,17 @@ def common_cluster_query(fn):
             ),
         ),
         click.option(
+            "--hybrids_off",
+            is_flag=True,
+            help=(
+                "Toggle to add BGCs with hybrid predicted classes/categories to each"
+                "subclass instead of a hybrid class/network (e.g. a 'terpene-nrps' BGC "
+                "would be added to both the terpene and NRPS classes/networks instead of"
+                " the terpene.nrps network)."
+                " Only works if --classify/--legacy_classify is selected."
+            ),
+        ),
+        click.option(
             "--alignment_mode",
             type=click.Choice(["global", "glocal", "auto"]),
             # TODO: define proper default

--- a/big_scape/cli/cli_validations.py
+++ b/big_scape/cli/cli_validations.py
@@ -285,6 +285,19 @@ def validate_binning_cluster_workflow(ctx) -> None:
         else:
             ctx.obj["legacy_weights"] = True
 
+    # --hybrids_off needs --legacy_classify or --classify
+
+    if ctx.obj["hybrids_off"]:
+        if not (ctx.obj["classify"] or ctx.obj["legacy_classify"]):
+            logging.error(
+                "You have selected --hybrids_off but no classification method. "
+                "Please select --classify or --legacy_classify"
+            )
+            raise click.UsageError(
+                "You have selected --hybrids_off but no classification method. "
+                "Please select --classify or --legacy_classify"
+            )
+
 
 def validate_binning_query_workflow(ctx) -> None:
     """Raise an error if the combination of parameters is invalid"""

--- a/big_scape/cli/query_cli.py
+++ b/big_scape/cli/query_cli.py
@@ -64,5 +64,4 @@ def query(ctx, *args, **kwarg):
     init_logger_file(ctx.obj)
 
     # run BiG-SCAPE
-    print(ctx.obj)
     run_bigscape(ctx.obj)

--- a/big_scape/comparison/binning.py
+++ b/big_scape/comparison/binning.py
@@ -761,11 +761,11 @@ def as_class_bin_generator(
             record_classes = [record_class]
 
         for record_class in record_classes:
-            try:
-                if record not in class_idx[record_class]:
-                    class_idx[record_class].append(record)
-            except KeyError:
+            if record_class not in class_idx:
                 class_idx[record_class] = [record]
+
+            if record_class in class_idx and record not in class_idx[record_class]:
+                class_idx[record_class].append(record)
 
             if weight_type == "legacy_weights":
                 # get region category for weights
@@ -921,11 +921,11 @@ def legacy_bin_generator(
         for product in record_products:
             record_class = legacy_get_class(product)
 
-            try:
-                if record not in class_idx[record_class]:
-                    class_idx[record_class].append(record)
-            except KeyError:
+            if record_class not in class_idx:
                 class_idx[record_class] = [record]
+
+            if record_class in class_idx and record not in class_idx[record_class]:
+                class_idx[record_class].append(record)
 
     for class_name, records in class_idx.items():
         edge_param_id = bs_comparison.get_edge_param_id(run, class_name)

--- a/big_scape/comparison/binning.py
+++ b/big_scape/comparison/binning.py
@@ -755,20 +755,27 @@ def as_class_bin_generator(
         if classify_mode == CLASSIFY_MODE.CATEGORY:
             record_class = get_record_category(record)
 
-        try:
-            class_idx[record_class].append(record)
-        except KeyError:
-            class_idx[record_class] = [record]
+        if run["hybrids_off"]:
+            record_classes = record_class.split(".")
+        else:
+            record_classes = [record_class]
 
-        if weight_type == "legacy_weights":
-            # get region category for weights
-            region_weight_cat = get_weight_category(record)
+        for record_class in record_classes:
+            try:
+                if record not in class_idx[record_class]:
+                    class_idx[record_class].append(record)
+            except KeyError:
+                class_idx[record_class] = [record]
 
-            if record_class not in category_weights.keys():
-                category_weights[record_class] = region_weight_cat
+            if weight_type == "legacy_weights":
+                # get region category for weights
+                region_weight_cat = get_weight_category(record)
 
-        if weight_type == "mix":
-            category_weights[record_class] = "mix"
+                if record_class not in category_weights.keys():
+                    category_weights[record_class] = region_weight_cat
+
+            if weight_type == "mix":
+                category_weights[record_class] = "mix"
 
     for class_name, records in class_idx.items():
         weight_category = category_weights[class_name]
@@ -903,15 +910,22 @@ def legacy_bin_generator(
         if record.product is None:
             continue
 
-        # product hybrids of AS4 and under dealt with here and in legacy_output generate_run_data_js
-        product = ".".join(record.product.split("-"))
+        product = record.product
 
-        record_class = legacy_get_class(product)
+        if run["hybrids_off"]:
+            record_products = product.split(".")
 
-        try:
-            class_idx[record_class].append(record)
-        except KeyError:
-            class_idx[record_class] = [record]
+        else:
+            record_products = [product]
+
+        for product in record_products:
+            record_class = legacy_get_class(product)
+
+            try:
+                if record not in class_idx[record_class]:
+                    class_idx[record_class].append(record)
+            except KeyError:
+                class_idx[record_class] = [record]
 
     for class_name, records in class_idx.items():
         edge_param_id = bs_comparison.get_edge_param_id(run, class_name)

--- a/big_scape/distances/query.py
+++ b/big_scape/distances/query.py
@@ -11,7 +11,9 @@ import big_scape.comparison as bs_comparison
 import big_scape.enums as bs_enums
 
 
-def calculate_distances_query(run: dict, gbks: list[bs_gbk.GBK]) -> None:
+def calculate_distances_query(
+    run: dict, gbks: list[bs_gbk.GBK]
+) -> list[bs_gbk.BGCRecord]:
     """calculates distances between all queries and references in a given dataset and
     saves them to the database
 
@@ -195,3 +197,5 @@ def calculate_distances_query(run: dict, gbks: list[bs_gbk.GBK]) -> None:
             break
 
         logging.info("Generated %d edges", num_edges)
+
+    return bgcs_records

--- a/big_scape/distances/query.py
+++ b/big_scape/distances/query.py
@@ -48,7 +48,18 @@ def calculate_distances_query(run: dict, gbks: list[bs_gbk.GBK]) -> None:
             # TODO: implement selection of specific query record if type is not region
             query_record = gbk.region
             bgcs_records.extend(gbk_records)
+            break
+
+    for gbk in gbks:
+        if gbk.region is None:
             continue
+        if gbk.region.product is None:
+            continue
+        if gbk.source_type == bs_enums.SOURCE_TYPE.QUERY:
+            continue
+
+        gbk_records = bs_gbk.bgc_record.get_sub_records(gbk.region, run["record_type"])
+
         # if classification mode is off, then use all records
         if not run["classify"]:
             query_singleton = False
@@ -61,24 +72,39 @@ def calculate_distances_query(run: dict, gbks: list[bs_gbk.GBK]) -> None:
             # if they have the same class/category as the query
             for gbk_record in gbk_records:
                 if classify_mode == bs_enums.CLASSIFY_MODE.CLASS:
-                    query_class = query_record.product
-                    record_class = gbk_record.product
-                    if record_class == query_class:
+                    query_class = [query_record.product]
+                    record_class = [gbk_record.product]
+
+                    if run["hybrids_off"]:
+                        query_class = query_class[0].split(".")
+                        record_class = record_class[0].split(".")
+
+                    intersect_class = list(set(query_class) & set(record_class))
+                    if len(intersect_class) > 0:
                         query_singleton = False
                         bgcs_records.append(gbk_record)
+
                 if classify_mode == bs_enums.CLASSIFY_MODE.CATEGORY:
-                    query_category = bs_comparison.get_record_category(query_record)
-                    record_category = bs_comparison.get_record_category(gbk_record)
-                    if record_category == query_category:
+                    query_category = [bs_comparison.get_record_category(query_record)]
+                    record_category = [bs_comparison.get_record_category(gbk_record)]
+
+                    if run["hybrids_off"]:
+                        query_category = query_category[0].split(".")
+                        record_category = record_category[0].split(".")
+
+                    intersect_cats = list(set(query_category) & set(record_category))
+                    if len(intersect_cats) > 0:
                         query_singleton = False
                         bgcs_records.append(gbk_record)
 
     if query_singleton:
         logging.error(
-            "Query record is a singleton, no other input records have the same class/category"
+            f"Query record {query_record.parent_gbk} is a singleton, no other input "
+            "records have the same class/category"
         )
         raise ValueError(
-            "Query record is a singleton, no other input records have the same class/category"
+            f"Query record {query_record.parent_gbk} is a singleton, no other input "
+            "records have the same class/category"
         )
 
     # if legacy weights are on, then use the legacy weights and pass as label to bin generator

--- a/big_scape/genbank/bgc_record.py
+++ b/big_scape/genbank/bgc_record.py
@@ -271,7 +271,7 @@ class BGCRecord:
         )
 
     @staticmethod
-    def parse_products(products: set[str]) -> str:
+    def parse_products(products: list[str]) -> str:
         """Parse a set of products from a BGC record. Used in cases where there are hybrid products
 
         Args:
@@ -283,6 +283,8 @@ class BGCRecord:
         # single product? just return it
         if len(products) == 1:
             return products.pop()
+
+        products.sort()
 
         # TODO: check the status here
         # return easy hybrids

--- a/big_scape/main.py
+++ b/big_scape/main.py
@@ -289,7 +289,7 @@ def run_bigscape(run: dict) -> None:
     if not run["no_mix"] and not run["query_bgc_path"]:
         edge_param_id = bs_comparison.get_edge_param_id(run, "mix")
         for cutoff in run["gcf_cutoffs"]:
-            logging.info("Bin 'mix': cutoff %s", cutoff)
+            logging.debug("Bin 'mix': cutoff %s", cutoff)
             for connected_component in bs_network.get_connected_components(
                 all_bgc_records, edge_param_id, cutoff
             ):
@@ -312,7 +312,7 @@ def run_bigscape(run: dict) -> None:
         for bin in bs_comparison.legacy_bin_generator(all_bgc_records, run):
             edge_param_id = bs_comparison.get_edge_param_id(run, bin.weights)
             for cutoff in run["gcf_cutoffs"]:
-                logging.info("Bin '%s': cutoff %s", bin.label, cutoff)
+                logging.debug("Bin '%s': cutoff %s", bin.label, cutoff)
                 for connected_component in bs_network.get_connected_components(
                     bin.source_records, edge_param_id, cutoff
                 ):
@@ -328,7 +328,7 @@ def run_bigscape(run: dict) -> None:
         for bin in bs_comparison.as_class_bin_generator(all_bgc_records, run):
             edge_param_id = bs_comparison.get_edge_param_id(run, bin.weights)
             for cutoff in run["gcf_cutoffs"]:
-                logging.info("Bin '%s': cutoff %s", bin.label, cutoff)
+                logging.debug("Bin '%s': cutoff %s", bin.label, cutoff)
                 for connected_component in bs_network.get_connected_components(
                     bin.source_records, edge_param_id, cutoff
                 ):

--- a/big_scape/main.py
+++ b/big_scape/main.py
@@ -273,7 +273,7 @@ def run_bigscape(run: dict) -> None:
     # query
 
     if run["query_bgc_path"]:
-        bs_query.calculate_distances_query(run, gbks)
+        query_records = bs_query.calculate_distances_query(run, gbks)
 
         DB.commit()
 
@@ -351,7 +351,7 @@ def run_bigscape(run: dict) -> None:
             logging.info("Query BGC Bin: cutoff %s", cutoff)
 
             query_connected_component = bs_network.get_query_connected_component(
-                all_bgc_records, query_node_id, edge_param_id, cutoff
+                query_records, query_node_id, edge_param_id, cutoff
             )
 
             cc_cutoff[cutoff] = query_connected_component
@@ -457,7 +457,7 @@ def run_bigscape(run: dict) -> None:
                 cc_cutoff[cutoff], "Query"
             )
             query_bin.add_records(
-                [record for record in all_bgc_records if record is not None]
+                [record for record in query_records if record is not None]
             )
             legacy_prepare_bin_output(run, cutoff, query_bin)
             legacy_generate_bin_output(run, cutoff, query_bin)

--- a/big_scape/main.py
+++ b/big_scape/main.py
@@ -287,10 +287,9 @@ def run_bigscape(run: dict) -> None:
     # mix
 
     if not run["no_mix"] and not run["query_bgc_path"]:
-        logging.info("-- Bin 'mix'")
         edge_param_id = bs_comparison.get_edge_param_id(run, "mix")
         for cutoff in run["gcf_cutoffs"]:
-            logging.info(" -- Cutoff %s", cutoff)
+            logging.info("Bin 'mix': cutoff %s", cutoff)
             for connected_component in bs_network.get_connected_components(
                 all_bgc_records, edge_param_id, cutoff
             ):
@@ -311,10 +310,9 @@ def run_bigscape(run: dict) -> None:
 
     if run["legacy_classify"] and not run["query_bgc_path"]:
         for bin in bs_comparison.legacy_bin_generator(all_bgc_records, run):
-            logging.info("-- Bin '%s'", bin.label)
             edge_param_id = bs_comparison.get_edge_param_id(run, bin.weights)
             for cutoff in run["gcf_cutoffs"]:
-                logging.info(" -- Cutoff %s", cutoff)
+                logging.info("Bin '%s': cutoff %s", bin.label, cutoff)
                 for connected_component in bs_network.get_connected_components(
                     bin.source_records, edge_param_id, cutoff
                 ):
@@ -328,10 +326,9 @@ def run_bigscape(run: dict) -> None:
 
     if run["classify"] and not run["query_bgc_path"]:
         for bin in bs_comparison.as_class_bin_generator(all_bgc_records, run):
-            logging.info("-- Bin '%s'", bin.label)
             edge_param_id = bs_comparison.get_edge_param_id(run, bin.weights)
             for cutoff in run["gcf_cutoffs"]:
-                logging.info(" -- Cutoff %s", cutoff)
+                logging.info("Bin '%s': cutoff %s", bin.label, cutoff)
                 for connected_component in bs_network.get_connected_components(
                     bin.source_records, edge_param_id, cutoff
                 ):
@@ -351,7 +348,7 @@ def run_bigscape(run: dict) -> None:
         edge_param_id = bs_comparison.get_edge_param_id(run, weights)
 
         for cutoff in run["gcf_cutoffs"]:
-            logging.info(" -- Cutoff %s", cutoff)
+            logging.info("Query BGC Bin: cutoff %s", cutoff)
 
             query_connected_component = bs_network.get_query_connected_component(
                 all_bgc_records, query_node_id, edge_param_id, cutoff

--- a/big_scape/network/network.py
+++ b/big_scape/network/network.py
@@ -253,6 +253,8 @@ def get_query_connected_component(
             distance_table.c.dss,
             distance_table.c.edge_param_id,
         )
+        .where(distance_table.c.record_a_id.in_(include_nodes))
+        .where(distance_table.c.record_b_id.in_(include_nodes))
         .where(
             (DB.metadata.tables["distance"].c.record_a_id.in_([query_node_id]))
             | (DB.metadata.tables["distance"].c.record_b_id.in_([query_node_id]))

--- a/big_scape/output/legacy_output.py
+++ b/big_scape/output/legacy_output.py
@@ -435,7 +435,7 @@ def generate_bigscape_results_js(output_dir: Path, label: str, cutoff: float) ->
         bigscape_results = []
 
     # check if run is already there. if so we can re use it
-    cutoff_label = f"{label}_c{cutoff:.1f}"
+    cutoff_label = f"{label}_c{cutoff}"
     bigscape_result = None
     for existing_result in bigscape_results:
         if existing_result["label"] == cutoff_label:
@@ -481,7 +481,7 @@ def add_bigscape_results_js_network(
     bigscape_results = read_bigscape_results_js(bigscape_results_js_path)
 
     # check if run is already there. if so we can re use it
-    cutoff_label = f"{label}_c{cutoff:.1f}"
+    cutoff_label = f"{label}_c{cutoff}"
     bigscape_result: dict[str, Any] = {"label": cutoff_label, "networks": []}
 
     for existing_result in bigscape_results:

--- a/big_scape/output/legacy_output.py
+++ b/big_scape/output/legacy_output.py
@@ -257,8 +257,7 @@ def generate_run_data_js(
         record_acc_idx = genomes[organism]
 
         # class id
-        # product hybrids of AS4 and under dealt with here and in legacy_bin_generator
-        product = ".".join(gbk.region.product.split("-"))
+        product = gbk.region.product
         region_class = legacy_get_class(product)
 
         if region_class not in class_idx:

--- a/test/comparison/test_binning.py
+++ b/test/comparison/test_binning.py
@@ -881,6 +881,7 @@ class TestBinGenerators(TestCase):
             "alignment_mode": bs_enums.ALIGNMENT_MODE.AUTO,
             "legacy_weights": True,
             "classify": bs_enums.CLASSIFY_MODE.CATEGORY,
+            "hybrids_off": False,
         }
 
         bin = next(as_class_bin_generator(gbks, run_category_weights))


### PR DESCRIPTION
implemented --hybrids-off flag, when toggled BGCs with hybrid classes/categories get put in the bins of all classes, and no hybrid class bins are made
so -> terpene.NRPS BGC gets put in the terpene and NRPS bin. (if not toggled, would be put in terpene.NRPS bin)

also minor bug fixing in product parsing and allowing cutoffs with more than 1 decimal