### PR TITLE
reflect antismash record type spelling

### DIFF
--- a/big_scape/cli/cli_common_options.py
+++ b/big_scape/cli/cli_common_options.py
@@ -282,7 +282,7 @@ def common_cluster_query(fn):
         click.option(
             "--alignment_mode",
             type=click.Choice(["global", "glocal", "auto"]),
-            # TODO: define proper default
+            # TODO: define proper default: v1 has glocal
             default="auto",
             callback=validate_alignment_mode,
             help=(
@@ -324,9 +324,7 @@ def common_cluster_query(fn):
         click.option(
             # TODO: double check that cand_cluster is proper implemented
             "--record_type",
-            type=click.Choice(
-                ["region", "cand_cluster", "proto_cluster", "proto_core"]
-            ),
+            type=click.Choice(["region", "cand_cluster", "protocluster", "proto_core"]),
             default="region",
             callback=validate_record_type,
             help="Use a specific type of record for comparison. Default: region",

--- a/big_scape/cli/cli_validations.py
+++ b/big_scape/cli/cli_validations.py
@@ -25,8 +25,8 @@ def set_start(param_dict) -> None:
     timestamp = start_time.strftime("%d-%m-%Y_%H-%M-%S")
     if param_dict["label"]:
         param_dict["label"] = f"{param_dict['label']}_{timestamp}"
-
-    param_dict["label"] = f"{timestamp}"
+    else:
+        param_dict["label"] = f"{timestamp}"
 
     param_dict["start_time"] = start_time
 

--- a/big_scape/cli/cli_validations.py
+++ b/big_scape/cli/cli_validations.py
@@ -41,8 +41,8 @@ def validate_profiling(ctx, param, profiling) -> bool:
 
     if profiling and platform.system() == "Darwin":
         logging.warning("Profiling is not supported on MacOS, please use Linux")
-
-    return False
+        return False
+    return profiling
 
 
 # input parameter validations

--- a/big_scape/cli/cli_validations.py
+++ b/big_scape/cli/cli_validations.py
@@ -351,12 +351,13 @@ def validate_pfam_path(ctx) -> None:
 
 def validate_record_type(ctx, _, record_type) -> Optional[bs_enums.genbank.RECORD_TYPE]:
     """Validates whether a region_type is provided when running classify"""
-    valid_types = [mode.value for mode in bs_enums.genbank.RECORD_TYPE]
+    valid_types = {mode.value: mode for mode in bs_enums.genbank.RECORD_TYPE}
 
-    for valid_type in valid_types:
-        if record_type == valid_type:
-            return bs_enums.genbank.RECORD_TYPE[valid_type.upper()]
-    return None
+    if record_type not in valid_types:
+        logging.error("Provided --record_type is invalid")
+        raise click.UsageError("Provided --record_type in invalid")
+
+    return valid_types[record_type]
 
 
 def validate_query_record(ctx) -> None:

--- a/big_scape/cli/config.py
+++ b/big_scape/cli/config.py
@@ -84,7 +84,7 @@ class BigscapeConfig:
         BigscapeConfig.CC_CONNECTIVITY_THRESHOLD = float(
             config["CLUSTER"]["CC_CONNECTIVITY_THRESHOLD"]
         )
-        BigscapeConfig.BETWEENNESS_CENTRALITY_NODES = int(
+        BigscapeConfig.BETWEENNESS_CENTRALITY_NODES = float(
             config["CLUSTER"]["BETWEENNESS_CENTRALITY_NODES"]
         )
 

--- a/big_scape/diagnostics/profiler.py
+++ b/big_scape/diagnostics/profiler.py
@@ -138,7 +138,7 @@ def make_plots(
     stats_df = stats_df.fillna(0.0)
     main_df = stats_df.pop("MAIN")
 
-    if stat_type == "mem":
+    if stat_type == "Memory":
         ylabel = "Memory (Mb)"
     else:
         ylabel = "CPU Percent"

--- a/big_scape/distances/mix.py
+++ b/big_scape/distances/mix.py
@@ -38,11 +38,11 @@ def calculate_distances_mix(
     if num_pairs > 0:
         logging.info("Calculating distances for %d pairs", num_pairs)
 
-        
         save_batch = []
         num_edges = 0
 
         with tqdm.tqdm(total=num_pairs, unit="edge", desc="Calculating distances") as t:
+
             def callback(edges):
                 nonlocal num_edges
                 nonlocal save_batch
@@ -59,13 +59,13 @@ def calculate_distances_mix(
             bs_comparison.generate_edges(
                 missing_edge_bin,
                 run["alignment_mode"],
-                run["cores"], run["cores"] * 2,
+                run["cores"],
+                run["cores"] * 2,
                 callback,
             )
 
+        bs_comparison.save_edges_to_db(save_batch)
 
-            bs_comparison.save_edges_to_db(save_batch)
+        bs_data.DB.commit()
 
-            bs_data.DB.commit()
-
-            logging.info("Generated %d edges", num_edges)
+        logging.info("Generated %d edges", num_edges)

--- a/big_scape/distances/query.py
+++ b/big_scape/distances/query.py
@@ -112,7 +112,8 @@ def calculate_distances_query(
         query_edges = bs_comparison.generate_edges(
             missing_edge_bin,
             run["alignment_mode"],
-            run["cores"], run["cores"] * 2,
+            run["cores"],
+            run["cores"] * 2,
         )
 
         num_edges = 0
@@ -161,7 +162,11 @@ def calculate_distances_query(
 
         # generate edges for these pairs
         ref_edges = bs_comparison.generate_edges(
-            ref_to_ref_bin, run["alignment_mode"], run["cores"], run["cores"] * 2, callback
+            ref_to_ref_bin,
+            run["alignment_mode"],
+            run["cores"],
+            run["cores"] * 2,
+            callback,
         )
 
         num_edges = 0
@@ -200,9 +205,7 @@ def calculate_distances_query(
         )
 
         query_edges = bs_comparison.generate_edges(
-            missing_ref_edge_bin,
-            run["alignment_mode"],
-            run["cores"],
+            missing_ref_edge_bin, run["alignment_mode"], run["cores"], run["cores"] * 2
         )
 
         num_edges = 0

--- a/big_scape/enums/genbank.py
+++ b/big_scape/enums/genbank.py
@@ -5,6 +5,6 @@ from enum import Enum
 
 class RECORD_TYPE(Enum):
     REGION = "region"
-    CANDIDATE_CLUSTER = "cand_cluster"
-    PROTO_CLUSTER = "proto_cluster"
+    CAND_CLUSTER = "cand_cluster"
+    PROTOCLUSTER = "protocluster"
     PROTO_CORE = "proto_core"

--- a/big_scape/enums/genbank.py
+++ b/big_scape/enums/genbank.py
@@ -6,5 +6,5 @@ from enum import Enum
 class RECORD_TYPE(Enum):
     REGION = "region"
     CAND_CLUSTER = "cand_cluster"
-    PROTOCLUSTER = "protocluster"
+    PROTO_CLUSTER = "protocluster"
     PROTO_CORE = "proto_core"

--- a/big_scape/genbank/bgc_record.py
+++ b/big_scape/genbank/bgc_record.py
@@ -456,7 +456,7 @@ def get_sub_records(
     # TODO: currently not implemented, only region, protocluster and protocore are supported
     # implement and use same strategy as for region if kind is neighbouring (several cores in a record)
     # and protocluster if kind is single, interleaved or chemical hybrid (one core per record)
-    if record_type == bs_enums.genbank.RECORD_TYPE.CANDIDATE_CLUSTER:
+    if record_type == bs_enums.genbank.RECORD_TYPE.CAND_CLUSTER:
         return cand_clusters
 
     # for protoclusters and protocores we need to keep track of the numbers, since they may
@@ -479,7 +479,7 @@ def get_sub_records(
     if len(proto_clusters) == 0:
         return cand_clusters
 
-    if record_type == bs_enums.genbank.RECORD_TYPE.PROTO_CLUSTER:
+    if record_type == bs_enums.genbank.RECORD_TYPE.PROTOCLUSTER:
         return proto_clusters
 
     proto_cores: list[ProtoCore] = []

--- a/big_scape/genbank/bgc_record.py
+++ b/big_scape/genbank/bgc_record.py
@@ -479,7 +479,7 @@ def get_sub_records(
     if len(proto_clusters) == 0:
         return cand_clusters
 
-    if record_type == bs_enums.genbank.RECORD_TYPE.PROTOCLUSTER:
+    if record_type == bs_enums.genbank.RECORD_TYPE.PROTO_CLUSTER:
         return proto_clusters
 
     proto_cores: list[ProtoCore] = []

--- a/big_scape/hmm/hmmer.py
+++ b/big_scape/hmm/hmmer.py
@@ -314,8 +314,6 @@ class HMMer:
         # an order to shut down
         # this way we can write the main process as follows:
 
-        tasks_done = 0
-
         # now that we have our worker processes and connections, we can start sending
         # data to the workers so they can actually start doing stuff
         while len(connections) > 0:
@@ -360,9 +358,8 @@ class HMMer:
                             task_output, cds_list, domain_overlap_cutoff
                         )
 
-                    tasks_done += src_task_count
                     if callback is not None:
-                        callback(tasks_done)
+                        callback(src_task_count)
 
         # almost certainly not every cds has an HSP, so we can only assume that if this reached the
         # end of the function all of the CDS were scanned.
@@ -465,8 +462,6 @@ class HMMer:
             hsps (list[HSP]): List of HSPs to align
         """
 
-        tasks_done = 0
-
         # emit a warning for people not using a certain version of pyhmmer
         version_parts = list(map(int, pyhmmer_version.split(".")))
         if int(version_parts[1]) < 8 or version_parts[1] == 8 and version_parts[2] < 2:
@@ -514,10 +509,8 @@ class HMMer:
 
             msa = hmmalign(domain_profile, ds_block)
 
-            tasks_done += 1
-
             if callback is not None:
-                callback(tasks_done)
+                callback(len(hsp_list))
 
             for idx, alignment in enumerate(msa.alignment):
                 # name is actually the list index of the original HSP

--- a/big_scape/main.py
+++ b/big_scape/main.py
@@ -171,7 +171,7 @@ def run_bigscape(run: dict) -> None:
                 run["cores"],
             )
 
-            with tqdm.tqdm(unit="CDS", desc="HMMSCAN") as t:
+            with tqdm.tqdm(unit="CDS", total=len(cds_to_scan), desc="HMMSCAN") as t:
 
                 def callback(tasks_done):
                     t.update(tasks_done)
@@ -229,7 +229,7 @@ def run_bigscape(run: dict) -> None:
 
         hsps_to_align = bs_data.get_hsp_to_align(gbks)
 
-        with tqdm.tqdm(unit="HSP", desc="HMMALIGN") as t:
+        with tqdm.tqdm(unit="HSP", total=len(hsps_to_align), desc="HMMALIGN") as t:
 
             def align_callback(tasks_done: int):
                 t.update(tasks_done)

--- a/big_scape/network/families.py
+++ b/big_scape/network/families.py
@@ -179,7 +179,7 @@ def aff_sim_matrix(matrix):
     warnings.filterwarnings(action="ignore", category=ConvergenceWarning)
 
     af_results = AffinityPropagation(
-        damping=0.9,
+        damping=0.90,
         max_iter=1000,
         convergence_iter=200,
         affinity="precomputed",
@@ -245,11 +245,7 @@ def save_singletons(record_type: RECORD_TYPE, cutoff: float, bin_label: str) -> 
         cutoff (float): cutoff value to create families for
         bin_label (str): label of the bin to create families for
     """
-    # TODO: fix protocluster spelling in RECORD_TYPE enum
-    if record_type == RECORD_TYPE.PROTO_CLUSTER:
-        record_type_str = "protocluster"
-    else:
-        record_type_str = record_type.value
+    record_type_str = record_type.value
 
     if DB.metadata is None:
         raise RuntimeError("DB metadata is None!")

--- a/test/genbank/test_gbk.py
+++ b/test/genbank/test_gbk.py
@@ -160,13 +160,13 @@ class TestGBK(TestCase):
         gbk_2 = GBK.parse(gbk_file_path_2, SOURCE_TYPE.QUERY, run)
 
         all_protoclusters_1 = bs_gbk.bgc_record.get_sub_records(
-            gbk_1.region, bs_enums.genbank.RECORD_TYPE.PROTO_CLUSTER
+            gbk_1.region, bs_enums.genbank.RECORD_TYPE.PROTOCLUSTER
         )
         protocluster_numbers_1 = [pc.number for pc in all_protoclusters_1]
         protocluster_numbers_1.sort()
 
         all_protoclusters_2 = bs_gbk.bgc_record.get_sub_records(
-            gbk_2.region, bs_enums.genbank.RECORD_TYPE.PROTO_CLUSTER
+            gbk_2.region, bs_enums.genbank.RECORD_TYPE.PROTOCLUSTER
         )
         protocluster_numbers_2 = [pc.number for pc in all_protoclusters_2]
         protocluster_numbers_2.sort()
@@ -184,7 +184,7 @@ class TestGBK(TestCase):
         proto_core_numbers_2.sort()
 
         all_cand_clusters_1 = bs_gbk.bgc_record.get_sub_records(
-            gbk_1.region, bs_enums.genbank.RECORD_TYPE.CANDIDATE_CLUSTER
+            gbk_1.region, bs_enums.genbank.RECORD_TYPE.CAND_CLUSTER
         )
         cand_cluster_numbers_1 = [cc.number for cc in all_cand_clusters_1]
         cand_cluster_numbers_1.sort()
@@ -196,7 +196,7 @@ class TestGBK(TestCase):
         cc_1_3_pcs.sort()
 
         all_cand_clusters_2 = bs_gbk.bgc_record.get_sub_records(
-            gbk_2.region, bs_enums.genbank.RECORD_TYPE.CANDIDATE_CLUSTER
+            gbk_2.region, bs_enums.genbank.RECORD_TYPE.CAND_CLUSTER
         )
         cand_cluster_numbers_2 = [cc.number for cc in all_cand_clusters_2]
         cand_cluster_numbers_2.sort()

--- a/test/genbank/test_gbk.py
+++ b/test/genbank/test_gbk.py
@@ -160,13 +160,13 @@ class TestGBK(TestCase):
         gbk_2 = GBK.parse(gbk_file_path_2, SOURCE_TYPE.QUERY, run)
 
         all_protoclusters_1 = bs_gbk.bgc_record.get_sub_records(
-            gbk_1.region, bs_enums.genbank.RECORD_TYPE.PROTOCLUSTER
+            gbk_1.region, bs_enums.genbank.RECORD_TYPE.PROTO_CLUSTER
         )
         protocluster_numbers_1 = [pc.number for pc in all_protoclusters_1]
         protocluster_numbers_1.sort()
 
         all_protoclusters_2 = bs_gbk.bgc_record.get_sub_records(
-            gbk_2.region, bs_enums.genbank.RECORD_TYPE.PROTOCLUSTER
+            gbk_2.region, bs_enums.genbank.RECORD_TYPE.PROTO_CLUSTER
         )
         protocluster_numbers_2 = [pc.number for pc in all_protoclusters_2]
         protocluster_numbers_2.sort()


### PR DESCRIPTION
small misc changes: make sure that record type enum has same spelling as antismash (enables --record_type cand_cluster), fix use of --label flag and parsing of float param