### PR TITLE
hotfix/edge-save-batch

### DIFF
--- a/big_scape/data/sqlite.py
+++ b/big_scape/data/sqlite.py
@@ -19,6 +19,7 @@ from sqlalchemy import (
     select,
     text,
 )
+from sqlalchemy.pool import StaticPool
 import tqdm
 import click
 
@@ -84,7 +85,11 @@ class DB:
         if DB.opened():
             raise DBAlreadyOpenError()
 
-        DB.engine = create_engine("sqlite:///:memory:")
+        DB.engine = create_engine(
+            "sqlite:///:memory:",
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
         DB.connection = DB.engine.connect()
 
     @staticmethod

--- a/big_scape/distances/mix.py
+++ b/big_scape/distances/mix.py
@@ -52,8 +52,7 @@ def calculate_distances_mix(
                     t.update(1)
                     save_batch.append(edge)
                     if len(save_batch) > batch_size:
-                        bs_comparison.save_edges_to_db(save_batch)
-                        bs_data.DB.commit()
+                        bs_comparison.save_edges_to_db(save_batch, commit=True)
                         save_batch = []
 
             bs_comparison.generate_edges(


### PR DESCRIPTION
(Feel free to look at this after the holidays)
Allows threads to insert created edges into database.

Uses global StaticPool to allow access from different threads
See: https://docs.sqlalchemy.org/en/14/dialects/sqlite.html#using-a-memory-database-in-multiple-threads

commit immediately from the threads' connection to ensure data is stored.

Unsure if you could ever have a situation where two threads finish at the same time causing them both to start inserting distances? seems unlikely...