### PR TITLE
Little fix for recipe

### DIFF
--- a/bigscape.py
+++ b/bigscape.py
@@ -1260,7 +1260,7 @@ def runHmmScan(fastaPath, hmmPath, outputdir, verbose):
         sys.exit("Error running hmmscan: Fasta file " + fastaPath + " doesn't exist")
 
 
-def parseHmmScan(hmmscanResults, pfd_folder, pfs_folder, overlapCutoff):
+def parseHmmScan(hmmscanResults, pfd_folder, pfs_folder, overlapCutoff, genbankDict):
     outputbase = ".".join(hmmscanResults.split(os.sep)[-1].split(".")[:-1])
     # try to read the domtable file to find out if this gbk has domains. Domains
     # need to be parsed into fastas anyway.
@@ -2519,7 +2519,7 @@ def main():
     # Using serialized version for now. Probably doesn't have too bad an impact
     #pool = Pool(cores,maxtasksperchild=32)
     for domtableFile in domtableFiles - alreadyDone:
-        parseHmmScan(domtableFile, pfd_folder, pfs_folder, options.domain_overlap_cutoff)
+        parseHmmScan(domtableFile, pfd_folder, pfs_folder, options.domain_overlap_cutoff, genbankDict)
         #pool.apply_async(parseHmmScan, args=(domtableFile,output_folder,options.domain_overlap_cutoff))
     #pool.close()
     #pool.join()

--- a/bigscape.py
+++ b/bigscape.py
@@ -63,7 +63,7 @@ from distutils import dir_util
 from sklearn.cluster import AffinityPropagation
 import networkx as nx
 
-from bgc_data import bgc_data
+from .bgc_data import bgc_data
 
 
 global use_relevant_mibig

--- a/bigscape.py
+++ b/bigscape.py
@@ -1960,10 +1960,10 @@ def CMD_parser():
                         Toggle to activate.")
     
     parser.add_argument("-d", "--domain_overlap_cutoff", 
-                        dest="domain_overlap_cutoff", default=0.1, help="Specify\
-                        at which overlap percentage domains are considered to \
-                        overlap. Domain with the best score is kept \
-                        (default=0.1).")
+                        dest="domain_overlap_cutoff", default=0.1, 
+                        type=float, help="Specify at which overlap percentage  \
+                        domains are considered to overlap. Domain with the best \
+                        score is kept (default=0.1).")
     
     parser.add_argument("-m", "--min_bgc_size", dest="min_bgc_size", default=0,
                       help="Provide the minimum size of a BGC to be included in\


### PR DESCRIPTION
Hello,

last week, I open an issue for updating the recipe for BiG-SCAPE (https://github.com/medema-group/BiG-SCAPE/issues/115).
After I pull the updated version into the Bioconda repository, the new version was tested. The test did fail (https://github.com/bioconda/bioconda-recipes/pull/44493 ; https://dev.azure.com/bioconda/bioconda-recipes/_build/results?buildId=49309&view=logs&j=e14e69ff-a0ae-55c4-b71d-229b239cfb2f&t=4dddc55b-10bc-50fc-ac68-7ff899b7a030). This means the recipe doesn't get updated. After investigate the error, the problem is that using an entry point doesn't work with the normal import with other .py files. In this case, this should fix it. 

Since the implication of BiG-SCAPE into Galaxy is nearly done, the only thing which blocks me right now is the recipe. In this case, it would be nice if you can change the current release with the updated version of 'bigscape.py' or create a new release with updated version. :)