### PR TITLE
fix bgc_data import issue

### DIFF
--- a/bigscape.py
+++ b/bigscape.py
@@ -1260,7 +1260,7 @@ def runHmmScan(fastaPath, hmmPath, outputdir, verbose):
         sys.exit("Error running hmmscan: Fasta file " + fastaPath + " doesn't exist")
 
 
-def parseHmmScan(hmmscanResults, pfd_folder, pfs_folder, overlapCutoff):
+def parseHmmScan(hmmscanResults, pfd_folder, pfs_folder, overlapCutoff, genbankDict):
     outputbase = ".".join(hmmscanResults.split(os.sep)[-1].split(".")[:-1])
     # try to read the domtable file to find out if this gbk has domains. Domains
     # need to be parsed into fastas anyway.
@@ -2519,7 +2519,7 @@ def main():
     # Using serialized version for now. Probably doesn't have too bad an impact
     #pool = Pool(cores,maxtasksperchild=32)
     for domtableFile in domtableFiles - alreadyDone:
-        parseHmmScan(domtableFile, pfd_folder, pfs_folder, options.domain_overlap_cutoff)
+        parseHmmScan(domtableFile, pfd_folder, pfs_folder, options.domain_overlap_cutoff, genbankDict)
         #pool.apply_async(parseHmmScan, args=(domtableFile,output_folder,options.domain_overlap_cutoff))
     #pool.close()
     #pool.join()

--- a/bigscape.py
+++ b/bigscape.py
@@ -1960,10 +1960,10 @@ def CMD_parser():
                         Toggle to activate.")
     
     parser.add_argument("-d", "--domain_overlap_cutoff", 
-                        dest="domain_overlap_cutoff", default=0.1, help="Specify\
-                        at which overlap percentage domains are considered to \
-                        overlap. Domain with the best score is kept \
-                        (default=0.1).")
+                        dest="domain_overlap_cutoff", default=0.1, 
+                        type=float, help="Specify at which overlap percentage  \
+                        domains are considered to overlap. Domain with the best \
+                        score is kept (default=0.1).")
     
     parser.add_argument("-m", "--min_bgc_size", dest="min_bgc_size", default=0,
                       help="Provide the minimum size of a BGC to be included in\

--- a/bigscape.py
+++ b/bigscape.py
@@ -63,7 +63,7 @@ from distutils import dir_util
 from sklearn.cluster import AffinityPropagation
 import networkx as nx
 
-from .bgc_data import bgc_data
+from bgc_data import bgc_data
 
 
 global use_relevant_mibig

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@
 import os
 from distutils.core import setup
 
+
 def generate_package_data():
     data_files = []
     for directory in ['html_template','Annotated_MIBiG_reference']:
@@ -17,7 +18,7 @@ def generate_package_data():
 
 setup(
      name='bigscape',
-     version='1.1.5',
+     version='1.1.8',
      py_modules=['functions','ArrowerSVG'],
      packages=["bigscape", "bgc_data"],
      package_dir={"bigscape": ".", "bgc_data": "."},

--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,8 @@ setup(
      name='bigscape',
      version='1.1.5',
      py_modules=['functions','ArrowerSVG'],
-     packages=['bigscape'],
-     package_dir={'bigscape': '.'},
+     packages=["bigscape", "bgc_data"],
+     package_dir={"bigscape": ".", "bgc_data": "."},
      package_data=generate_package_data(),
      entry_points={
          'console_scripts': ['bigscape=bigscape.__main__:main']


### PR DESCRIPTION
The current release does not work via pip or conda. 
This PR tries to use this idea to fix it:https://github.com/medema-group/BiG-SCAPE/pull/118
Now the package should work locally and installed via pip / conda.

Would it be possible, that you release this fix as 1.1.8; that would allow us to create the build. 

As a short explanation, we are trying to integrate this tool into Galaxy (https://usegalaxy.eu/), but therefore we need a working bioconda recipe. 

If you do not want to follow this up, would you mind if the release the bioconda recipe via a fork where we add those fixes ? 


