### PR TITLE
Feature/edge gen performance

### DIFF
--- a/big_scape/comparison/binning.py
+++ b/big_scape/comparison/binning.py
@@ -198,16 +198,16 @@ class QueryToRefRecordPairGenerator(RecordPairGenerator):
     def generate_pairs(
         self, legacy_sorting=False
     ) -> Generator[tuple[int, int], None, None]:
-        """Returns an Generator for Region pairs in this bin, all pairs are generated
+        """Returns an Generator for record pairs in this bin, all pairs are generated
         except for ref <-> ref pairs
 
         Args:
             legacy_sorting (bool, optional): Whether to sort the BGC records by GBK file name.
             This is done in BiG-SCAPE 1.0 and can affect scoring depending on which of
-            the BGC records is region A in a pair.
+            the BGC records is record A in a pair.
 
         Yields:
-            Generator[RegionPair]: Generator for Region pairs in this bin
+            Generator[tuple[int, int]]: Generator for record pairs in this bin
         """
         for query_idx, record_a in enumerate(self.query_records):
             query_start = query_idx + 1
@@ -289,17 +289,16 @@ class RefToRefRecordPairGenerator(RecordPairGenerator):
     def generate_pairs(
         self, legacy_sorting=False
     ) -> Generator[tuple[int, int], None, None]:
-        """Returns an Generator for Region pairs in this bin, pairs are only generated between
-        given nodes to all singleton ref nodes
+        """Returns an Generator for record pairs in this bin, pairs are only generated
+        between given nodes to all singleton ref nodes
 
         Args:
-            network (BSNetwork): A network object to use for finding and sorting the nodes.
-            all records in this bin must be in the network as nodes, with or without edges
-
-            given_nodes (list[BGCRecord]): List of BGC records to generate pairs from
+            legacy_sorting (bool, optional): Whether to sort the BGC records by GBK file name.
+            This is done in BiG-SCAPE 1.0 and can affect scoring depending on which of
+            the BGC records is record A in a pair.
 
         Yields:
-            Generator[RegionPair]: Generator for Region pairs in this bin
+            Generator[tuple[int, int]]: Generator for record pairs in this bin
         """
 
         singleton_reference_records = self.get_singleton_reference_nodes()
@@ -593,7 +592,16 @@ class ConnectedComponentPairGenerator(RecordPairGenerator):
     def generate_pairs(
         self, legacy_sorting=False
     ) -> Generator[tuple[int, int], None, None]:
-        """Returns a Generator for all pairs in this bin"""
+        """Returns an Generator for record pairs in this bin
+
+        Args:
+            legacy_sorting (bool, optional): Whether to sort the BGC records by GBK file name.
+            This is done in BiG-SCAPE 1.0 and can affect scoring depending on which of
+            the BGC records is record A in a pair.
+
+        Yields:
+            Generator[tuple[int, int]]: Generator for record pairs in this bin
+        """
 
         for edge in self.connected_component:
             record_a_id, record_b_id, dist, jacc, adj, dss, edge_param_id = edge
@@ -652,6 +660,16 @@ class MissingRecordPairGenerator(RecordPairGenerator):
     def generate_pairs(
         self, legacy_sorting=False
     ) -> Generator[tuple[int, int], None, None]:
+        """Returns an Generator for record pairs in this bin
+
+        Args:
+            legacy_sorting (bool, optional): Whether to sort the BGC records by GBK file name.
+            This is done in BiG-SCAPE 1.0 and can affect scoring depending on which of
+            the BGC records is record A in a pair.
+
+        Yields:
+            Generator[tuple[int, int]]: Generator for record pairs in this bin
+        """
         if not DB.metadata:
             raise RuntimeError("DB.metadata is None")
 

--- a/big_scape/comparison/binning.py
+++ b/big_scape/comparison/binning.py
@@ -62,7 +62,7 @@ class RecordPairGenerator:
     def generate_pairs(
         self, legacy_sorting=False
     ) -> Generator[tuple[int, int], None, None]:
-        """Returns a generator for all vs all Region pairs in this bins
+        """Returns a generator for all vs all record pairs in this bins
 
         This will always generate all pairs, and does not take into account any edges
         that already exist in the database
@@ -70,10 +70,10 @@ class RecordPairGenerator:
         Args:
             legacy_sorting (bool, optional): Whether to sort the BGC records by GBK file name.
             This is done in BiG-SCAPE 1.0 and can affect scoring depending on which of
-            the BGC regions is region A in a pair. TODO: may be removed in the future
+            the BGC records is record A in a pair. TODO: may be removed in the future
 
         Yields:
-            Generator[tuple[int, int]]: Generator for Region pairs in this bin
+            Generator[tuple[int, int]]: Generator for record pairs in this bin
         """
         for record_a, record_b in combinations(self.source_records, 2):
             if record_a.parent_gbk == record_b.parent_gbk:
@@ -104,8 +104,8 @@ class RecordPairGenerator:
             the BGC records is region A in a pair.
 
         Yields:
-            Generator[list[RegionPair], None, None]]: Generator for Region pairs in this
-            bin
+            Generator[list[tuple[int, int]], None, None]]: Generator for records pairs
+            in this bin
         """
         batch = []
         while pair := next(self.generate_pairs(legacy_sorting), None):

--- a/big_scape/comparison/workflow.py
+++ b/big_scape/comparison/workflow.py
@@ -367,8 +367,8 @@ def calculate_scores_pair(
     """Calculate the scores for a list of pairs
 
     Args:
-        data (tuple[list[RecordPair], str, str]): list of pairs, alignment mode, bin
-        label
+        data (tuple[list[tuple[int, int]], str, str]): list of pairs, alignment mode,
+        bin label
 
     Returns:
         list[tuple[int, int, float, float, float, float, int, int, int, int, int, int,

--- a/big_scape/data/partial_task.py
+++ b/big_scape/data/partial_task.py
@@ -6,7 +6,7 @@ Also contains functions to determine subsets of tasks that need to be done
 
 # from python
 from __future__ import annotations
-from typing import TYPE_CHECKING, Generator
+from typing import TYPE_CHECKING, Generator, Optional
 
 # from dependencies
 from sqlalchemy import select
@@ -17,7 +17,6 @@ import big_scape.enums as bs_enums
 
 # from circular imports
 if TYPE_CHECKING:
-    from big_scape.comparison.record_pair import RecordPair
     from big_scape.comparison import RecordPairGenerator
     from big_scape.genbank.gbk import GBK, CDS
     from big_scape.hmm import HSP
@@ -235,9 +234,10 @@ def get_comparison_data_state(gbks: list[GBK]) -> bs_enums.COMPARISON_TASK:
     return bs_enums.COMPARISON_TASK.ALL_DONE
 
 
+# TODO: does not seem to be used
 def get_missing_distances(
     pair_generator: RecordPairGenerator,
-) -> Generator[RecordPair, None, None]:
+) -> Generator[tuple[Optional[int], Optional[int]], None, None]:
     """Get a generator of BGCPairs that are missing from a network
 
     Args:
@@ -265,5 +265,5 @@ def get_missing_distances(
 
     for pair in pair_generator.generate_pairs():
         # if the pair is not in the set of existing distances, yield it
-        if (pair.record_a._db_id, pair.record_b._db_id) not in existing_distances:
+        if pair not in existing_distances and pair[::-1] not in existing_distances:
             yield pair

--- a/test/comparison/test_binning.py
+++ b/test/comparison/test_binning.py
@@ -38,6 +38,7 @@ def create_mock_gbk(i, source_type: bs_enums.SOURCE_TYPE) -> GBK:
     cds.strand = 1
     gbk.genes.append(cds)
     gbk.region = Region(gbk, 1, 0, 100, False, "test")
+    gbk.region._db_id = i
     gbk.metadata = {
         "organism": "banana",
         "taxonomy": "bananus;fruticus",
@@ -171,10 +172,13 @@ class TestBGCBin(TestCase):
 
         gbk_a = GBK(Path("test1.gbk"), "test1", "test")
         bgc_a = BGCRecord(gbk_a, 0, 0, 10, False, "")
+        bgc_a._db_id = 1
         gbk_b = GBK(Path("test2.gbk"), "test2", "test")
         bgc_b = BGCRecord(gbk_b, 0, 0, 10, False, "")
+        bgc_b._db_id = 2
         gbk_c = GBK(Path("test3.gbk"), "test3", "test")
         bgc_c = BGCRecord(gbk_c, 0, 0, 10, False, "")
+        bgc_c._db_id = 3
 
         # due to the order, this should generate a list of pairs as follows without legacy sort:
         # bgc_a, bgc_c
@@ -188,14 +192,13 @@ class TestBGCBin(TestCase):
 
         # expected list should correctly sort the third entry int the list to be bgc_b, bgc_c
         expected_pair_list = [
-            (bgc_a, bgc_c),
-            (bgc_a, bgc_b),
-            (bgc_b, bgc_c),
+            (bgc_a._db_id, bgc_c._db_id),
+            (bgc_a._db_id, bgc_b._db_id),
+            (bgc_b._db_id, bgc_c._db_id),
         ]
 
         actual_pair_list = [
-            tuple([pair.record_a, pair.record_b])
-            for pair in new_bin.generate_pairs(legacy_sorting=True)
+            pair for pair in new_bin.generate_pairs(legacy_sorting=True)
         ]
 
         self.assertEqual(expected_pair_list, actual_pair_list)
@@ -223,7 +226,7 @@ class TestBGCBin(TestCase):
 
         expected_pairs = []
         for ref_gbk in ref_gbks:
-            expected_pair = RecordPair(query_gbk.region, ref_gbk.region)
+            expected_pair = (query_gbk.region._db_id, ref_gbk.region._db_id)
             expected_pairs.append(expected_pair)
 
         # get all edges
@@ -330,10 +333,10 @@ class TestBGCBin(TestCase):
         # this is rough, so let's type it all out
         expected_pairs = set(
             [
-                RecordPair(ref_gbks[0].region, ref_gbks[2].region),
-                RecordPair(ref_gbks[0].region, ref_gbks[3].region),
-                RecordPair(ref_gbks[1].region, ref_gbks[2].region),
-                RecordPair(ref_gbks[1].region, ref_gbks[3].region),
+                (ref_gbks[0].region._db_id, ref_gbks[2].region._db_id),
+                (ref_gbks[0].region._db_id, ref_gbks[3].region._db_id),
+                (ref_gbks[1].region._db_id, ref_gbks[2].region._db_id),
+                (ref_gbks[1].region._db_id, ref_gbks[3].region._db_id),
             ]
         )
 
@@ -558,7 +561,7 @@ class TestBGCBin(TestCase):
         # now we can do the second iteration
         expected_pairs = set(
             [
-                RecordPair(ref_gbks[2].region, ref_gbks[3].region),
+                (ref_gbks[3].region._db_id, ref_gbks[2].region._db_id),
             ]
         )
 
@@ -631,9 +634,9 @@ class TestBGCBin(TestCase):
 
         expected_pairs = set(
             [
-                RecordPair(query_gbk.region, ref_gbks[0].region),
-                RecordPair(query_gbk.region, ref_gbks[1].region),
-                RecordPair(ref_gbks[0].region, ref_gbks[1].region),
+                (query_gbk.region._db_id, ref_gbks[0].region._db_id),
+                (query_gbk.region._db_id, ref_gbks[1].region._db_id),
+                (ref_gbks[0].region._db_id, ref_gbks[1].region._db_id),
             ]
         )
         # expected_record_ids = [1, 2, 3]
@@ -762,12 +765,15 @@ class TestMixComparison(TestCase):
 
         bgc_a = BGCRecord(gbk1, 0, 0, 10, False, "")
         bgc_a.parent_gbk = gbk1
+        bgc_a._db_id = 1
 
         bgc_b = BGCRecord(gbk2, 0, 0, 10, False, "")
         bgc_b.parent_gbk = gbk2
+        bgc_b._db_id = 2
 
         bgc_c = BGCRecord(gbk3, 0, 0, 10, False, "")
         bgc_c.parent_gbk = gbk3
+        bgc_c._db_id = 3
 
         bgc_list = [bgc_a, bgc_b, bgc_c]
 

--- a/test/db/test_partial.py
+++ b/test/db/test_partial.py
@@ -6,7 +6,6 @@ return the state of partial analyses so that they can be continued
 from pathlib import Path
 from unittest import TestCase
 from itertools import combinations
-import big_scape.comparison.record_pair
 
 # from other modules
 from big_scape.data import (
@@ -34,6 +33,7 @@ def create_mock_gbk(i) -> GBK:
     cds.strand = 1
     gbk.genes.append(cds)
     gbk.region = Region(gbk, 1, 0, 100, False, "test")
+    gbk.region._db_id = i
     gbk.metadata = {
         "organism": "banana",
         "taxonomy": "bananus;fruticus",
@@ -506,8 +506,8 @@ class TestPartialComparison(TestCase):
         mix_bin.add_records([gbk.region for gbk in gbks])
 
         expected_missing_pairs = [
-            big_scape.comparison.record_pair.RecordPair(gbks[0].region, gbks[2].region),
-            big_scape.comparison.record_pair.RecordPair(gbks[1].region, gbks[2].region),
+            (gbks[0].region._db_id, gbks[2].region._db_id),
+            (gbks[1].region._db_id, gbks[2].region._db_id),
         ]
 
         pair_generator = bs_comparison.RecordPairGenerator("mix", 1)


### PR DESCRIPTION
Edge generation performance improvement:
- Pair generation refactored to produce pairs of database ids
- Sends batch of pairs of database ids to threads
- threads fetch minimally required data from database and reconstruct gbk/record/cds/hsp objects
- distance calculation proceeds as normal

Also includes some outdated syntax updates, e.g. region-> record

Based on tests, default batch size of 50k achieved ~highest edge/s 
When using a single thread, this and the original show ~the same speed