### PR TITLE
correct expected pairs for multiple subrecords

### DIFF
--- a/big_scape/comparison/binning.py
+++ b/big_scape/comparison/binning.py
@@ -22,7 +22,7 @@ from big_scape.cli.constants import ANTISMASH_CLASSES
 from big_scape.comparison.record_pair import RecordPair
 from big_scape.data import DB
 from big_scape.genbank import BGCRecord, Region, ProtoCluster, ProtoCore
-from big_scape.enums import SOURCE_TYPE, CLASSIFY_MODE
+from big_scape.enums import SOURCE_TYPE, CLASSIFY_MODE, RECORD_TYPE
 
 import big_scape.comparison as bs_comparison
 
@@ -51,7 +51,13 @@ class RecordPairGenerator:
         source_records (list[BGCRecord]): List of BGC records to generate pairs from
     """
 
-    def __init__(self, label: str, edge_param_id: int, weights: Optional[str] = None):
+    def __init__(
+        self,
+        label: str,
+        edge_param_id: int,
+        weights: Optional[str] = None,
+        record_type: Optional[RECORD_TYPE] = None,
+    ):
         self.label = label
         self.edge_param_id = edge_param_id
         self.source_records: list[BGCRecord] = []
@@ -59,6 +65,7 @@ class RecordPairGenerator:
         if weights is None:
             weights = label
         self.weights = weights
+        self.record_type = record_type
 
     def generate_pairs(self, legacy_sorting=False) -> Generator[RecordPair, None, None]:
         """Returns a generator for all vs all Region pairs in this bins
@@ -122,6 +129,36 @@ class RecordPairGenerator:
 
         # (n*(n-1)) / 2
         num_all_pairs = int((len_all_records * (len_all_records - 1)) / 2)
+
+        if self.record_type is not None and self.record_type != RECORD_TYPE.REGION:
+            # if in protocluster mode this will overestimate the number of pairs as two
+            # records from the same gbk will not be compared -> will not be a pair. Use
+            # the database to find how many subrecords come from the same genbank, i.e.
+            # how many pairs should be removed
+            if not DB.metadata:
+                raise RuntimeError("DB metadata is None!")
+            record_table = DB.metadata.tables["bgc_record"]
+
+            # find a collection of gbks with more than one subrecord
+            member_table = (
+                select(func.count(record_table.c.gbk_id).label("rec_count"))
+                .where(record_table.c.record_type == self.record_type.value)
+                .group_by(record_table.c.gbk_id)
+                .having(func.count() > 1)
+                .subquery()
+            )
+            # count how many times each occurs, e.g. gbks with 3 records occur 4 times
+            subrecord_membership = select(
+                member_table.c.rec_count, func.count(member_table.c.rec_count)
+            ).group_by(member_table.c.rec_count)
+
+            subrecord_counts = DB.execute(subrecord_membership).fetchall()
+
+            # for each occurence of a number of subrecords, remove pairs
+            if subrecord_counts is not None:
+                for row in subrecord_counts:
+                    nr_subrec, occurence = row
+                    num_all_pairs -= int((nr_subrec * (nr_subrec - 1)) / 2 * occurence)
 
         return num_all_pairs
 
@@ -662,7 +699,7 @@ class MissingRecordPairGenerator(RecordPairGenerator):
 
 
 def generate_mix_bin(
-    record_list: list[BGCRecord], edge_param_id: int
+    record_list: list[BGCRecord], edge_param_id: int, record_type: RECORD_TYPE
 ) -> RecordPairGenerator:
     """Generate an all-vs-all bin of the supplied BGC records
 
@@ -673,7 +710,9 @@ def generate_mix_bin(
         BGCBin: The all-vs-all BGC bin
     """
 
-    mix_bin = RecordPairGenerator(label="mix", edge_param_id=edge_param_id)
+    mix_bin = RecordPairGenerator(
+        label="mix", edge_param_id=edge_param_id, record_type=record_type
+    )
 
     mix_bin.add_records([record for record in record_list if record is not None])
 
@@ -752,7 +791,9 @@ def as_class_bin_generator(
     for class_name, records in class_idx.items():
         weight_category = category_weights[class_name]
         edge_param_id = bs_comparison.get_edge_param_id(run, weight_category)
-        bin = RecordPairGenerator(class_name, edge_param_id, weight_category)
+        bin = RecordPairGenerator(
+            class_name, edge_param_id, weight_category, run["record_type"]
+        )
         bin.add_records(records)
         yield bin
 
@@ -901,7 +942,9 @@ def legacy_bin_generator(
 
     for class_name, records in class_idx.items():
         edge_param_id = bs_comparison.get_edge_param_id(run, class_name)
-        bin = RecordPairGenerator(class_name, edge_param_id, class_name)
+        bin = RecordPairGenerator(
+            class_name, edge_param_id, class_name, run["record_type"]
+        )
         bin.add_records(records)
         yield bin
 

--- a/big_scape/distances/mix.py
+++ b/big_scape/distances/mix.py
@@ -27,7 +27,9 @@ def calculate_distances_mix(
 
     edge_param_id = bs_comparison.get_edge_param_id(run, "mix")
 
-    mix_bin = bs_comparison.generate_mix_bin(list_bgc_records, edge_param_id)
+    mix_bin = bs_comparison.generate_mix_bin(
+        list_bgc_records, edge_param_id, run["record_type"]
+    )
 
     logging.info(mix_bin)
 

--- a/big_scape/distances/query.py
+++ b/big_scape/distances/query.py
@@ -189,7 +189,9 @@ def calculate_distances_query(
 
     query_nodes = bs_network.get_nodes_from_cc(query_connected_component, query_records)
 
-    query_connected_bin = bs_comparison.RecordPairGenerator("Query", edge_param_id)
+    query_connected_bin = bs_comparison.RecordPairGenerator(
+        "Query", edge_param_id, record_type=run["record_type"]
+    )
     query_connected_bin.add_records(query_nodes)
 
     # fetch any existing distances from database

--- a/big_scape/main.py
+++ b/big_scape/main.py
@@ -429,7 +429,9 @@ def run_bigscape(run: dict) -> None:
 
     if not run["no_mix"] and not run["query_bgc_path"]:
         edge_param_id = bs_comparison.get_edge_param_id(run, "mix")
-        mix_bin = bs_comparison.generate_mix_bin(all_bgc_records, edge_param_id)
+        mix_bin = bs_comparison.generate_mix_bin(
+            all_bgc_records, edge_param_id, run["record_type"]
+        )
 
         for cutoff in run["gcf_cutoffs"]:
             if not run["include_singletons"]:

--- a/test/comparison/test_binning.py
+++ b/test/comparison/test_binning.py
@@ -166,6 +166,44 @@ class TestBGCBin(TestCase):
 
         self.assertEqual(expected_num_pairs, actual_num_pairs)
 
+    def test_num_pairs_corrected_multiple_subrecords(self):
+        """Tests whether number of expected pairs is corrected for subrecords from the
+        same gbk"""
+        bs_data.DB.create_in_mem()
+
+        gbk1 = create_mock_gbk(0, bs_enums.SOURCE_TYPE.QUERY)
+        pclust1 = ProtoCluster(gbk1, 1, 10, 100, False, "", {})
+        pclust2 = ProtoCluster(gbk1, 2, 50, 200, False, "", {})
+        gbk1.region.cand_clusters[1] = CandidateCluster(
+            gbk1, 0, 10, 100, False, "", "", {1: pclust1, 2: pclust2}
+        )
+        gbk1.save_all()
+
+        gbk2 = create_mock_gbk(1, bs_enums.SOURCE_TYPE.QUERY)
+        pclust3 = ProtoCluster(gbk2, 1, 10, 100, False, "", {})
+        pclust4 = ProtoCluster(gbk2, 2, 50, 200, False, "", {})
+        pclust5 = ProtoCluster(gbk2, 3, 200, 300, False, "", {})
+        gbk2.region.cand_clusters[1] = CandidateCluster(
+            gbk1, 0, 10, 100, False, "", "", {1: pclust3, 2: pclust4, 3: pclust5}
+        )
+        gbk2.save_all()
+
+        gbk3 = create_mock_gbk(2, bs_enums.SOURCE_TYPE.QUERY)
+        gbk3.save_all()
+
+        records = [pclust1, pclust2, pclust3, pclust4, pclust5, gbk3.region]
+        bin = RecordPairGenerator(
+            "test", 1, record_type=bs_enums.RECORD_TYPE.PROTO_CLUSTER
+        )
+        bin.add_records(records)
+
+        # with 6 total records, we would normally expect 15 pairs
+        # subtract one for gbk1 and subtract 3 for gbk2
+        expected_pairs = 11
+        actual_pairs = bin.num_pairs()
+
+        self.assertEqual(expected_pairs, actual_pairs)
+
     def test_legacy_sorting(self):
         """Tests whether the legacy sorting option in bin.pairs() correctly orders the pairs"""
 
@@ -771,7 +809,7 @@ class TestMixComparison(TestCase):
 
         bgc_list = [bgc_a, bgc_b, bgc_c]
 
-        new_bin = generate_mix_bin(bgc_list, 1)
+        new_bin = generate_mix_bin(bgc_list, 1, bs_enums.RECORD_TYPE.REGION)
 
         # expected representation of the bin object
         expected_pair_count = 3
@@ -906,6 +944,7 @@ class TestBinGenerators(TestCase):
             "legacy_weights": True,
             "classify": bs_enums.CLASSIFY_MODE.CATEGORY,
             "hybrids_off": False,
+            "record_type": bs_enums.RECORD_TYPE.REGION,
         }
 
         bin = next(as_class_bin_generator(gbks, run_category_weights))


### PR DESCRIPTION
- Pass RECORD_TYPE to RecordPairGenerator where needed
- Query database for every occurrence of a gbk with multiple subrecords
- Correct num_pairs 