### PR TITLE
fix setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,9 +19,9 @@ def generate_package_data():
 setup(
      name='bigscape',
      version='1.1.8',
-     py_modules=['functions','ArrowerSVG'],
-     packages=["bigscape", "bgc_data"],
-     package_dir={"bigscape": ".", "bgc_data": "."},
+     py_modules=['functions','ArrowerSVG', "bgc_data"],
+     packages=["bigscape"],
+     package_dir={"bigscape": "."},
      package_data=generate_package_data(),
      entry_points={
          'console_scripts': ['bigscape=bigscape.__main__:main']


### PR DESCRIPTION
I don't know why I thought my last fix made sense, the fix I made actually imported `bgc_data` as a module, which allowed it to be imported but when the tool runs it fails with `cannot import module `. I tested the new fix by installing via pip 
```
pip3 install .
bigscape --version
```
and running via
```
python bigscape.py --version
```
Now both works. Can you please make a new release or update the last one, sorry for the hiccup;
we will be happy to add you as creator to the galaxy wrapper !