### PR TITLE
Feature/faster cc gen

### DIFF
--- a/big_scape/data/schema.sql
+++ b/big_scape/data/schema.sql
@@ -106,7 +106,14 @@ CREATE TABLE IF NOT EXISTS distance (
     FOREIGN KEY(record_a_id) REFERENCES bgc_record(id)
     FOREIGN KEY(record_b_id) REFERENCES bgc_record(id)
     FOREIGN KEY(edge_param_id) REFERENCES edge_params(id)
+);
 
+CREATE TABLE IF NOT EXISTS connected_component (
+    id INTEGER NOT NULL,
+    record_id INTEGER NOT NULL,
+    cutoff REAL NOT NULL,
+    unique(record_id, cutoff),
+    FOREIGN KEY(record_id) REFERENCES bgc_record(id)
 );
 
 CREATE TABLE IF NOT EXISTS edge_params (

--- a/big_scape/data/schema.sql
+++ b/big_scape/data/schema.sql
@@ -112,6 +112,7 @@ CREATE TABLE IF NOT EXISTS connected_component (
     id INTEGER NOT NULL,
     record_id INTEGER NOT NULL,
     cutoff REAL NOT NULL,
+    edge_param_id INTEGER NOT NULL,
     unique(record_id, cutoff),
     FOREIGN KEY(record_id) REFERENCES bgc_record(id)
 );

--- a/big_scape/distances/query.py
+++ b/big_scape/distances/query.py
@@ -183,9 +183,12 @@ def calculate_distances_query(
 
     # now we make any last connected ref <-> connected ref pairs that are missing
     # get all the edges in the query connected component
-    query_connected_component = bs_network.get_query_connected_component(
-        query_records, query_record._db_id, edge_param_id, 1
+    query_connected_component = bs_network.get_connected_components(
+        edge_param_id, 1, query_records
     )
+
+    # get_connected_components returns a list of connected components, we only want the first one
+    query_connected_component = next(query_connected_component)
 
     query_nodes = bs_network.get_nodes_from_cc(query_connected_component, query_records)
 

--- a/big_scape/distances/query.py
+++ b/big_scape/distances/query.py
@@ -42,7 +42,7 @@ def calculate_distances_query(
             query_singleton = False
             query_records.append(record)
 
-        # if classification mode is on, then us only those records which have the query class/category
+        # if classification mode is on, then use only those records which have the query class/category
         if run["classify"]:
             classify_mode = run["classify"]
             # now we go to all the records, of a given type, of the gbk and check
@@ -91,7 +91,7 @@ def calculate_distances_query(
 
     edge_param_id = bs_comparison.get_edge_param_id(run, weights)
 
-    # generate inital query -> ref pairs
+    # generate initial query -> ref pairs
     query_to_ref_bin = bs_comparison.QueryToRefRecordPairGenerator(
         "Query_Ref", edge_param_id, weights
     )
@@ -126,17 +126,21 @@ def calculate_distances_query(
 
     if run["skip_propagation"]:
         return query_records
+    
+    # at this point we have query -> ref edges
+    # we now need to propagate edges from those ref -> other ref
 
-    # now we expand these edges from reference to other reference
     # TODO: see if we can implement missing for these
     ref_to_ref_bin = bs_comparison.RefToRefRecordPairGenerator(
         "Ref_Ref", edge_param_id, weights
     )
     ref_to_ref_bin.add_records(query_records)
 
+    # we will continue propagating until there are no more edges to generate
     while True:
         # fetches the current number of singleton ref <-> connected ref pairs from the database
         num_pairs = ref_to_ref_bin.num_pairs()
+        
         # if there are no more singleton ref <-> connected ref pairs, then break and exit
         if num_pairs == 0:
             break
@@ -184,7 +188,7 @@ def calculate_distances_query(
     # now we make any last connected ref <-> connected ref pairs that are missing
     # get all the edges in the query connected component
     query_connected_component = bs_network.get_connected_components(
-        edge_param_id, 1, query_records
+        1, edge_param_id, query_records
     )
 
     # get_connected_components returns a list of connected components, we only want the first one

--- a/big_scape/main.py
+++ b/big_scape/main.py
@@ -310,7 +310,7 @@ def run_bigscape(run: dict) -> None:
         for cutoff in run["gcf_cutoffs"]:
             logging.debug("Bin 'mix': cutoff %s", cutoff)
             for connected_component in bs_network.get_connected_components(
-                edge_param_id, cutoff, all_bgc_records
+                cutoff, edge_param_id, all_bgc_records
             ):
                 logging.debug(
                     "Found connected component with %d edges", len(connected_component)
@@ -334,7 +334,7 @@ def run_bigscape(run: dict) -> None:
             for cutoff in run["gcf_cutoffs"]:
                 logging.debug("Bin '%s': cutoff %s", bin.label, cutoff)
                 for connected_component in bs_network.get_connected_components(
-                    edge_param_id, cutoff, bin.source_records
+                    cutoff, edge_param_id, bin.source_records
                 ):
                     regions_families = bs_families.generate_families(
                         connected_component, bin.label, cutoff
@@ -352,7 +352,7 @@ def run_bigscape(run: dict) -> None:
             for cutoff in run["gcf_cutoffs"]:
                 logging.debug("Bin '%s': cutoff %s", bin.label, cutoff)
                 for connected_component in bs_network.get_connected_components(
-                    edge_param_id, cutoff, bin.source_records
+                    cutoff, edge_param_id, bin.source_records
                 ):
                     regions_families = bs_families.generate_families(
                         connected_component, bin.label, cutoff
@@ -378,9 +378,10 @@ def run_bigscape(run: dict) -> None:
 
             # get_connected_components returns a list of connected components, but we only
             # want the first one, so we use next()
+            
             query_connected_component = next(
                 bs_network.get_connected_components(
-                    edge_param_id, cutoff, query_records
+                    cutoff, edge_param_id, [query_record]
                 )
             )
 


### PR DESCRIPTION
This is basically the same approach as before, but now uses a connected_component table to assemble connected components instead of doing a bunch of it in-memory, resulting in huge SQL statements


TODO:
- [x] Fix include_records problem
Current pull request does not fix the problem of a large connected component being used in query mode; This still ends up with a large query if the query bgc ends up in a massive connected component.
detailed todo: insert the query bgc record(s) as connected components and just expand those only

Mark as reviewable once todo is done