### PR TITLE
fix default config

### DIFF
--- a/big_scape/cli/cli_common_options.py
+++ b/big_scape/cli/cli_common_options.py
@@ -1,10 +1,11 @@
 """Click parameter that are shared between multiple BiG-SCAPE modules"""
 
 # from python
-import os
 import click
 from multiprocessing import cpu_count
 from pathlib import Path
+
+import big_scape.paths as bs_paths
 
 # from this module
 from .cli_validations import (
@@ -36,7 +37,7 @@ def common_all(fn):
             type=click.Path(
                 exists=True, dir_okay=False, file_okay=True, path_type=Path
             ),
-            default=Path(os.getcwd()) / "./config.yml",
+            default=Path(bs_paths.DEFAULT_CONFIG_FILE),
             help="Path to BiG-SCAPE config file, which stores values for a "
             "series of advanced use parameters. (default: [working directory]/config.yml). "
             "If this file does not exist, uses a default file packaged with BiG-SCAPE "

--- a/big_scape/cli/cli_common_options.py
+++ b/big_scape/cli/cli_common_options.py
@@ -39,9 +39,7 @@ def common_all(fn):
             ),
             default=Path(bs_paths.DEFAULT_CONFIG_FILE),
             help="Path to BiG-SCAPE config file, which stores values for a "
-            "series of advanced use parameters. (default: [working directory]/config.yml). "
-            "If this file does not exist, uses a default file packaged with BiG-SCAPE "
-            "([big_scape package]/config.yml).",
+            "series of advanced use parameters. (default: bundled big_scape/config.yml).",
         ),
         # diagnostic parameters
         click.option(

--- a/big_scape/paths.py
+++ b/big_scape/paths.py
@@ -6,4 +6,4 @@ DB_SCHEMA_FILE = pkg_resources.resource_filename(
     "bigscape", "big_scape/data/schema.sql"
 )
 TEMPLATES_OUTPUT_DIR = pkg_resources.resource_filename("bigscape", "big_scape/output")
-DEFAULT_CONFIG_FILE = pkg_resources.resource_filename("bigscape", "config.ini")
+DEFAULT_CONFIG_FILE = pkg_resources.resource_filename("bigscape", "config.yml")

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -19,3 +19,4 @@ types-psutil
 networkx-stubs
 data-science-types
 types-tqdm
+types-setuptools


### PR DESCRIPTION
Easiest way to fix the default config: don't check for it in the working directory. only use a custom one when a user provides one with --config_file_path