### PR TITLE
Hotfix/query

### DIFF
--- a/big_scape/cli/cli_common_options.py
+++ b/big_scape/cli/cli_common_options.py
@@ -339,7 +339,7 @@ def common_cluster_query(fn):
             "-db",
             "--db_path",
             type=click.Path(path_type=Path, dir_okay=False),
-            help="Path to sqlite db output file. (default: output_dir/data_sqlite.db).",
+            help="Path to sqlite db output file. (default: output_dir/output_dir.db).",
         ),
         # TODO: implement cand_cluster here and LCS-ext
         click.option(

--- a/big_scape/cli/cli_common_options.py
+++ b/big_scape/cli/cli_common_options.py
@@ -274,21 +274,6 @@ def common_cluster_query(fn):
             ),
         ),
         click.option(
-            "--legacy_classify",
-            is_flag=True,
-            help=(
-                "Does not use antiSMASH BGC classes to run analyses on "
-                "class-based bins, instead it uses BiG-SCAPE v1 predefined groups: "
-                "PKS1, PKSOther, NRPS, NRPS-PKS-hybrid, RiPP, Saccharide, Terpene, Others. "
-                "Will also use BiG-SCAPE v1 legacy_weights for distance calculations. "
-                "This feature is available for backwards compatibility with "
-                "antiSMASH versions up to v7. For higher antiSMASH versions, use "
-                "at your own risk, as BGC classes may have changed. All antiSMASH "
-                "classes that this legacy mode does not recognize will be grouped in "
-                "'others'."
-            ),
-        ),
-        click.option(
             "--alignment_mode",
             type=click.Choice(["global", "glocal", "local", "auto"]),
             default="glocal",

--- a/big_scape/cli/cli_validations.py
+++ b/big_scape/cli/cli_validations.py
@@ -112,7 +112,7 @@ def validate_output_paths(ctx) -> None:
     timestamp = time.strftime("%Y-%m-%d_%H-%M-%S", time.localtime())
 
     if "db_path" in ctx.obj and ctx.obj["db_path"] is None:
-        db_path = ctx.obj["output_dir"] / Path("data_sqlite.db")
+        db_path = ctx.obj["output_dir"] / Path(f"{ctx.obj['output_dir'].name}.db")
         ctx.obj["db_path"] = db_path
 
     if "log_path" in ctx.obj and ctx.obj["log_path"] is None:

--- a/big_scape/cli/cluster_cli.py
+++ b/big_scape/cli/cluster_cli.py
@@ -35,6 +35,21 @@ from .cli_validations import (
 )
 # binning parameters
 @click.option("--no_mix", is_flag=True, help=("Don't run the all-vs-all analysis."))
+@click.option(
+    "--legacy_classify",
+    is_flag=True,
+    help=(
+        "Does not use antiSMASH BGC classes to run analyses on "
+        "class-based bins, instead it uses BiG-SCAPE v1 predefined groups: "
+        "PKS1, PKSOther, NRPS, NRPS-PKS-hybrid, RiPP, Saccharide, Terpene, Others. "
+        "Will also use BiG-SCAPE v1 legacy_weights for distance calculations. "
+        "This feature is available for backwards compatibility with "
+        "antiSMASH versions up to v7. For higher antiSMASH versions, use "
+        "at your own risk, as BGC classes may have changed. All antiSMASH "
+        "classes that this legacy mode does not recognize will be grouped in "
+        "'others'."
+    ),
+)
 # networking parameters
 @click.option(
     "--include_singletons",

--- a/big_scape/cli/query_cli.py
+++ b/big_scape/cli/query_cli.py
@@ -73,6 +73,7 @@ def query(ctx, *args, **kwarg):
     ctx.obj.update(ctx.params)
     ctx.obj["no_mix"] = None
     ctx.obj["hybrids_off"] = False
+    ctx.obj["legacy_classify"] = False
     ctx.obj["mode"] = "Query"
 
     # workflow validations

--- a/big_scape/cli/query_cli.py
+++ b/big_scape/cli/query_cli.py
@@ -49,14 +49,13 @@ from .cli_validations import (
     ),
 )
 @click.option(
-    "--skip_propagation",
+    "--propagate",
     is_flag=True,
     help=(
-        "Only generate edges between the query and reference BGCs. If not set, "
-        "BiG-SCAPE will also propagate edge generation to reference BGCs. "
-        "Warning: if the database already contains all edges, this will not work, "
-        "and the output will still showcase all edges between nodes "
-        "in the query connected component."
+        "By default, BiG-SCAPE will only generate edges between the query and reference"
+        " BGCs. With the propagate flag, BiG-SCAPE will go through multiple cycles of "
+        "edge generation until no new reference BGCs are connected to the query "
+        "connected component."
     ),
 )
 @click.pass_context

--- a/big_scape/distances/query.py
+++ b/big_scape/distances/query.py
@@ -43,7 +43,9 @@ def calculate_distances_query(
     max_cutoff = max(run["gcf_cutoffs"])
     edge_param_id = bs_comparison.get_edge_param_id(run, weights)
 
-    query_bin = bs_comparison.QueryRecordPairGenerator("Query", edge_param_id, weights)
+    query_bin = bs_comparison.QueryRecordPairGenerator(
+        "Query", edge_param_id, weights, run["record_type"]
+    )
     query_bin.add_records(query_records)
 
     missing_query_bin = bs_comparison.QueryMissingRecordPairGenerator(query_bin)

--- a/big_scape/distances/query.py
+++ b/big_scape/distances/query.py
@@ -56,9 +56,13 @@ def calculate_distances_query(
 
     query_connected_component = next(
         bs_network.get_connected_components(
-            max_cutoff, edge_param_id, query_bin, run["run_id"]
-        )
+            max_cutoff, edge_param_id, query_bin, run["run_id"], query_record
+        ),
+        None,
     )
+    if query_connected_component is None:
+        # no nodes are connected even with the highest cutoffs in the run
+        return query_bin
 
     query_nodes = bs_network.get_nodes_from_cc(query_connected_component, query_records)
 
@@ -161,47 +165,56 @@ def calculate_distances(run: dict, bin: bs_comparison.RecordPairGenerator):
         # fetches the current number of singleton ref <-> connected ref pairs from the database
         num_pairs = bin.num_pairs()
 
-        # if there are no more singleton ref <-> connected ref pairs, then break and exit
-        if num_pairs == 0:
-            break
+        if num_pairs > 0:
+            logging.info("Calculating distances for %d pairs", num_pairs)
 
-        logging.info("Calculating distances for %d pairs", num_pairs)
+            save_batch = []
+            num_edges = 0
 
-        save_batch = []
-        num_edges = 0
+            with tqdm.tqdm(
+                total=num_pairs, unit="edge", desc="Calculating distances"
+            ) as t:
 
-        with tqdm.tqdm(total=num_pairs, unit="edge", desc="Calculating distances") as t:
+                def callback(edges):
+                    nonlocal num_edges
+                    nonlocal save_batch
+                    batch_size = run["cores"] * 100000
+                    for edge in edges:
+                        num_edges += 1
+                        t.update(1)
+                        save_batch.append(edge)
+                        if len(save_batch) > batch_size:
+                            bs_comparison.save_edges_to_db(save_batch, commit=True)
+                            save_batch = []
 
-            def callback(edges):
-                nonlocal num_edges
-                nonlocal save_batch
-                batch_size = run["cores"] * 100000
-                for edge in edges:
-                    num_edges += 1
-                    t.update(1)
-                    save_batch.append(edge)
-                    if len(save_batch) > batch_size:
-                        bs_comparison.save_edges_to_db(save_batch, commit=True)
-                        save_batch = []
+                bs_comparison.generate_edges(
+                    bin,
+                    run["alignment_mode"],
+                    run["extend_strategy"],
+                    run["cores"],
+                    run["cores"] * 2,
+                    callback,
+                )
 
-            bs_comparison.generate_edges(
-                bin,
-                run["alignment_mode"],
-                run["extend_strategy"],
-                run["cores"],
-                run["cores"] * 2,
-                callback,
-            )
+            bs_comparison.save_edges_to_db(save_batch)
 
-        bs_comparison.save_edges_to_db(save_batch)
+            bs_data.DB.commit()
 
-        bs_data.DB.commit()
-
-        logging.info("Generated %d edges", num_edges)
+            logging.info("Generated %d edges", num_edges)
 
         if run["skip_propagation"]:
             # in this case we only want one iteration, the Query -> Ref edges
             break
 
+        if isinstance(bin, bs_comparison.MissingRecordPairGenerator):
+            # in this case we only need edges within one cc, no cycles needed
+            break
+
         if isinstance(bin, bs_comparison.QueryMissingRecordPairGenerator):
+            # use the num_pairs from the parent bin because in a partial database,
+            # all distances for the first cycle(s) might already be present.
+            # we still only want to stop when no other connected nodes are discovered.
+            if bin.bin.num_pairs() == 0:
+                break
+
             bin.cycle_records(max(run["gcf_cutoffs"]))

--- a/big_scape/distances/query.py
+++ b/big_scape/distances/query.py
@@ -202,7 +202,7 @@ def calculate_distances(run: dict, bin: bs_comparison.RecordPairGenerator):
 
             logging.info("Generated %d edges", num_edges)
 
-        if run["skip_propagation"]:
+        if not run["propagate"]:
             # in this case we only want one iteration, the Query -> Ref edges
             break
 

--- a/big_scape/network/families.py
+++ b/big_scape/network/families.py
@@ -370,34 +370,38 @@ def run_family_assignments_query(
         # get_connected_components returns a list of connected components, but we only
         # want the first one, so we use next()
 
-        try:
-            query_connected_component = next(
-                bs_network.get_connected_components(
-                    cutoff, query_bin.edge_param_id, query_bin, run["run_id"]
-                )
-            )
+        query_connected_component = next(
+            bs_network.get_connected_components(
+                cutoff,
+                query_bin.edge_param_id,
+                query_bin,
+                run["run_id"],
+                query_record,
+            ),
+            None,
+        )
 
-            cc_cutoff[cutoff] = query_connected_component
-
-            logging.debug(
-                "Found connected component with %d edges",
-                len(query_connected_component),
-            )
-
-            regions_families = generate_families(
-                query_connected_component, query_bin.label, cutoff, run["run_id"]
-            )
-
-            # save families to database
-            save_to_db(regions_families)
-
-        except StopIteration:
+        if query_connected_component is None:
             logging.warning(
                 "No connected components found for %s bin at cutoff %s",
                 query_bin.label,
                 cutoff,
             )
             continue
+
+        cc_cutoff[cutoff] = query_connected_component
+
+        logging.debug(
+            "Found connected component with %d edges",
+            len(query_connected_component),
+        )
+
+        regions_families = generate_families(
+            query_connected_component, query_bin.label, cutoff, run["run_id"]
+        )
+
+        # save families to database
+        save_to_db(regions_families)
 
     DB.commit()
 

--- a/big_scape/network/network.py
+++ b/big_scape/network/network.py
@@ -32,6 +32,7 @@ def get_connected_components(
     edge_param_id: int,
     bin: bs_comparison.RecordPairGenerator,
     run_id: int,
+    seed_record: Optional[BGCRecord] = None,
 ) -> Generator[list[tuple[int, int, float, float, float, float, int]], None, None]:
     """Generate a network for each connected component in the network
         If a seed record is given, the connected component will be generated starting from that record
@@ -54,7 +55,7 @@ def get_connected_components(
 
     # generate connected components using dfs
     generate_connected_components(
-        cutoff, edge_param_id, bin.label, run_id, include_record_table
+        cutoff, edge_param_id, bin.label, run_id, include_record_table, seed_record
     )
 
     cc_ids = get_connected_component_ids(

--- a/big_scape/output/html_template/output/html_content/css/style.css
+++ b/big_scape/output/html_template/output/html_content/css/style.css
@@ -24,7 +24,6 @@ html[data-theme='dark'] {
   --overview-button-background: hsl(var(--hue), 34%, 48%);
   --button-text-color: hsl(var(--hue), 10%, 10%);
   --background-color: hsl(var(--hue), 20%, 12%);
-  /* --background-header: rgba(159, 159, 143, 0.188); */
   --background-header: hsl(var(--hue), 15%, 20%);
   --li-selected-color: hsl(var(--hue), 70%, 60%);
   --row-selected-color: hsl(var(--hue), 60%, 70%)
@@ -160,6 +159,7 @@ a.anchor {
   color: var(--text-color-normal);
   background-color: var(--background-color);
   overflow: scroll;
+  opacity: 90%;
 }
 
 .desc-container.active {

--- a/big_scape/output/html_template/output/html_content/js/bigscape.js
+++ b/big_scape/output/html_template/output/html_content/js/bigscape.js
@@ -360,11 +360,9 @@ function Bigscape(run_data, bs_data, bs_families, bs_alignment, bs_similarity, n
     var ui = Viva.Graph.svg('circle')
       .attr('r', 10)
       .attr('fill', (fam_colors[bs_to_cl[node.id]]));
-    if (run_data["mode"] == "Cluster") {
-      if (bs_data[node.id]["source"] == "mibig" || bs_data[node.id]["source"] == "reference") {
-        ui.attr("stroke", "blue");
-        ui.attr("stroke-width", "4px");
-      }
+    if (bs_data[node.id]["source"] == "mibig" || bs_data[node.id]["source"] == "reference") {
+      ui.attr("stroke", "blue");
+      ui.attr("stroke-width", "4px");
     }
     if (run_data["mode"] == "Query") {
       if (bs_data[node.id]["source"] == "query") {

--- a/big_scape/output/html_template/output/index.html
+++ b/big_scape/output/html_template/output/index.html
@@ -228,8 +228,8 @@
                     <span>Filter the connected components table. All filters allow for comma separated input that will
                         be handled as logical OR operators.</span>
                     <div>
-                        <input id="organism-filter" placeholder="Search Organisms">
-                        <span>Fuzzy search organism names, e.g. "Streptomyces"</span>
+                        <input id="desc-filter" placeholder="Search Descriptions">
+                        <span>Fuzzy search GBK descriptions, e.g. "Streptomyces"</span>
                     </div>
                     <div>
                         <input id="bgc-filter" placeholder="Search BGC Names">
@@ -392,7 +392,7 @@
         $("#cc-table-filters").toggleClass("hidden")
     })
     $("#clear-filters").on("click", (event) => {
-        $("#organism-filter").val("")
+        $("#desc-filter").val("")
         $("#bgc-filter").val("")
         $("#domain-filter").val("")
         $("#family-filter").val("")
@@ -558,7 +558,7 @@
         run_params["cutoff"] = cutoff
         var bin_label = $("#network-selection option:selected").text()
 
-        var org_filter = $("#organism-filter").val().toString().trim()
+        var org_filter = $("#desc-filter").val().toString().trim()
         var pf_filter = $("#domain-filter").val().toString().trim()
         var fam_filter = $("#family-filter").val().toString().trim()
         var bgc_filter = $("#bgc-filter").val().toString().trim()
@@ -573,7 +573,7 @@
                 AND connected_component.bin_label=="${bin_label}"`
 
         if (org_filter) {
-            var conditions = org_filter.split(",").map(org => `gbk.organism LIKE "%${org.trim()}%"`)
+            var conditions = org_filter.split(",").map(org => `gbk.description LIKE "%${org.trim()}%"`)
             cc_query += ` AND (${conditions.join(" OR ")})`
         }
         if (pf_filter) {
@@ -647,7 +647,7 @@
         }
         var tsv_text = `# Collection of selected connected components
 # Run info: ${run_data["label"]} ${run_data["cutoff"]} ${$("#network-selection option:selected").text()}
-# Organism filter: ${$("#organism-filter").val()}
+# Description filter: ${$("#desc-filter").val()}
 # BGC filter: ${$("#bgc-filter").val()}
 # Pfam filter: ${$("#domain-filter").val()}
 # Family filter: ${$("#family-filter").val()}\n
@@ -672,7 +672,7 @@ CC\tFamily\tGBK\tRecord_Type\tRecord_Number\tClass\tCategory\tOrganism\tTaxonomy
             if (!dom_data.hasOwnProperty(cds_id)) {
                 dom_data[cds_id] = []
             }
-            dom_data[cds_id].push({ "code": domains[i][1], "start": domains[i][2], "end": domains[i][3], "bitscore": domains[i][4] })
+            dom_data[cds_id].push({ "code": domains[i][1], "start": domains[i][2], "end": domains[i][3], "bitscore": domains[i][4].toFixed(3) })
         }
         return dom_data
     }
@@ -693,7 +693,7 @@ CC\tFamily\tGBK\tRecord_Type\tRecord_Number\tClass\tCategory\tOrganism\tTaxonomy
         return cds_data
     }
     function generate_bs_data(record_ids, run_data) {
-        var records_query = `SELECT gbk.id, gbk.organism, length(gbk.nt_seq), gbk.hash, gbk.path,
+        var records_query = `SELECT gbk.id, gbk.description, length(gbk.nt_seq), gbk.hash, gbk.path,
                         bgc_record.record_type, bgc_record.nt_start, bgc_record.nt_stop,
                         bgc_record.record_number, bgc_record.id FROM bgc_record
                         INNER JOIN gbk ON bgc_record.gbk_id==gbk.id
@@ -733,16 +733,16 @@ CC\tFamily\tGBK\tRecord_Type\tRecord_Number\tClass\tCategory\tOrganism\tTaxonomy
             }
             new_row["record_start"] = rec_start
             new_row["record_stop"] = rec_stop
+
+            if (gbk_path.indexOf(run_data["reference_dir"]) > -1) {
+                new_row["source"] = "reference"
+            }
+            if (gbk_path.indexOf(`mibig_antismash_${run_data["mibig_version"]}_gbk`) > -1) {
+                new_row["source"] = "mibig"
+            }
             if (run_data["mode"] == "Query") {
                 if (filename == run_data["query_path"]) {
                     new_row["source"] = "query"
-                }
-            } else {
-                if (gbk_path.indexOf(run_data["reference_dir"]) > -1) {
-                    new_row["source"] = "reference"
-                }
-                if (gbk_path.indexOf(run_data["mibig_version"]) > -1) {
-                    new_row["source"] = "mibig"
                 }
             }
             bs_data[record_id] = new_row

--- a/test/comparison/test_binning.py
+++ b/test/comparison/test_binning.py
@@ -161,7 +161,7 @@ class TestBGCBin(TestCase):
         for bgc in bgc_list:
             bgc.save_record("Region")
 
-        new_bin = QueryRecordPairGenerator("test", 1, "mix")
+        new_bin = QueryRecordPairGenerator("test", 1, "mix", None)
 
         new_bin.add_records(bgc_list)
 
@@ -290,7 +290,7 @@ class TestBGCBin(TestCase):
             create_mock_gbk(i, bs_enums.SOURCE_TYPE.REFERENCE) for i in range(1, 4)
         ]
 
-        query_to_ref_pair_generator = QueryRecordPairGenerator("mix", 1, "mix")
+        query_to_ref_pair_generator = QueryRecordPairGenerator("mix", 1, "mix", None)
         source_records = [query_gbk.region]
 
         for ref_gbk in ref_gbks:

--- a/test/integration/test_comparison.py
+++ b/test/integration/test_comparison.py
@@ -1020,7 +1020,9 @@ class TestComparison(TestCase):
             create_mock_gbk(i, bs_enums.SOURCE_TYPE.REFERENCE) for i in range(1, 5)
         ]
 
-        query_pair_generator = bs_comparison.QueryRecordPairGenerator("mix", 1, "mix")
+        query_pair_generator = bs_comparison.QueryRecordPairGenerator(
+            "mix", 1, "mix", None
+        )
         source_records = [query_gbk.region]
         for ref_gbk in ref_gbks:
             source_records.append(ref_gbk.region)
@@ -1147,7 +1149,9 @@ class TestComparison(TestCase):
             create_mock_gbk(i, bs_enums.SOURCE_TYPE.REFERENCE) for i in range(1, 5)
         ]
 
-        query_pair_generator = bs_comparison.QueryRecordPairGenerator("mix", 1, "mix")
+        query_pair_generator = bs_comparison.QueryRecordPairGenerator(
+            "mix", 1, "mix", None
+        )
         source_records = [query_gbk.region]
         for ref_gbk in ref_gbks:
             source_records.append(ref_gbk.region)
@@ -1488,7 +1492,7 @@ class TestComparison(TestCase):
 
         # generate initial query -> ref pairs
         query_bin = bs_comparison.QueryRecordPairGenerator(
-            "Query", edge_param_id, weights
+            "Query", edge_param_id, weights, run["record_type"]
         )
         query_bin.add_records(query_records)
 
@@ -1610,7 +1614,9 @@ class TestComparison(TestCase):
 
         query_record, list_bgc_records = create_mock_query_dataset(run)
 
-        query_to_ref_bin = bs_comparison.QueryRecordPairGenerator("Query_Ref", 1, "mix")
+        query_to_ref_bin = bs_comparison.QueryRecordPairGenerator(
+            "Query_Ref", 1, "mix", run["record_type"]
+        )
         query_records = bs_query.get_query_records(run, list_bgc_records, query_record)
 
         query_to_ref_bin.add_records(query_records)

--- a/test/integration/test_comparison.py
+++ b/test/integration/test_comparison.py
@@ -1471,7 +1471,7 @@ class TestComparison(TestCase):
             "record_type": bs_enums.RECORD_TYPE.REGION,
             "cores": 1,
             "classify": bs_enums.CLASSIFY_MODE.CLASS,
-            "skip_propagation": False,
+            "propagate": True,
             "gcf_cutoffs": [0.1, 0.7],
         }
 
@@ -1607,7 +1607,7 @@ class TestComparison(TestCase):
             "record_type": bs_enums.RECORD_TYPE.REGION,
             "cores": 1,
             "classify": bs_enums.CLASSIFY_MODE.CLASS,
-            "skip_propagation": False,
+            "propagate": True,
             "run_id": 1,
             "gcf_cutoffs": [0.1, 0.8],
         }


### PR DESCRIPTION
By default, BiG-SCAPE will not propagate in query mode. 
Database name is now output_dir.db
Query mode now runs correctly in the following cases:
- With any existing database, i.e. a propagate run after a no propagate run or after a cluster run
- in protocluster/core mode

