### PR TITLE
fix yield statement

### DIFF
--- a/big_scape/genbank/bgc_record.py
+++ b/big_scape/genbank/bgc_record.py
@@ -93,7 +93,8 @@ class BGCRecord:
         if return_all:
             # TODO: I don't like this solution. maybe go back to the more difficult one
             if reverse:
-                return reversed(self.parent_gbk.genes)
+                yield from reversed(self.parent_gbk.genes)
+                return
 
             yield from self.parent_gbk.genes
             return


### PR DESCRIPTION
This should have affected every single case where reverse CDSs were needed, aka every single case where the LCS on a pair with B reversed was longer than B forward. Big oops.