### PR TITLE
add flag to force save the database to disk

### DIFF
--- a/big_scape/data/sqlite.py
+++ b/big_scape/data/sqlite.py
@@ -106,7 +106,7 @@ class DB:
         DB.reflect()
 
     @staticmethod
-    def save_to_disk(db_path: Path) -> None:
+    def save_to_disk(db_path: Path, force=False) -> None:
         """Saves the in-memory database to a .db file. This overwrites any last database
         file in the same location
         """
@@ -116,7 +116,13 @@ class DB:
         click_context = click.get_current_context(silent=True)
 
         if click_context and click_context.obj["no_db_dump"]:
-            return
+            # added force to override this override. fun times.
+            # this is used when you use the --no-db-dump flag so that we can force it
+            # to save at the end anyway
+            # TODO: this logic should be moved out, where the no_db_dump flag is checked
+            # when it is appropriate to do so
+            if not force:
+                return
 
         if not DB.opened():
             raise DBClosedError()

--- a/big_scape/run_bigscape.py
+++ b/big_scape/run_bigscape.py
@@ -352,6 +352,6 @@ def run_bigscape(run: dict) -> None:
     exec_time = end - start_time
 
     bs_data.DB.set_run_end(run["run_id"], start_time, end)
-    bs_data.DB.save_to_disk(run["db_path"])
+    bs_data.DB.save_to_disk(run["db_path"], True)
 
     logging.info("All tasks done at %f seconds", exec_time.total_seconds())


### PR DESCRIPTION
This adds a flag to the save_to_disk call that overrides the no-db-dump option. In terms of control flow, separation of concerns and general code this isn't great, but it is fast and effective.