### PR TITLE
add no tree generation flag

### DIFF
--- a/big_scape/cli/cli_common_options.py
+++ b/big_scape/cli/cli_common_options.py
@@ -118,7 +118,8 @@ def common_all(fn):
             is_flag=True,
             default=False,
             help="Do not generate any output besides the data stored in the database. "
-            "Suitable for advanced users that work with the SQL database directly.",
+            "Suitable for advanced users that wish to only make use of the results "
+            "stored in the SQLite database.",
         ),
         click.option(
             "--no-trees",
@@ -126,7 +127,8 @@ def common_all(fn):
             is_flag=True,
             default=False,
             help="Do not generate any GCF newick trees. Suitable for users that do not "
-            "utilize our output visualization, but work with output tsv files directly.",
+            "utilize our output visualization, but only make use of the output stored "
+            "in the tsv files and/or SQLite database.",
         ),
         click.option(
             "--force-gbk",

--- a/big_scape/cli/cli_common_options.py
+++ b/big_scape/cli/cli_common_options.py
@@ -113,7 +113,7 @@ def common_all(fn):
             "runs with limited memory.",
         ),
         click.option(
-            "--no-output",
+            "--db-only-output",
             type=bool,
             is_flag=True,
             default=False,

--- a/big_scape/cli/cli_common_options.py
+++ b/big_scape/cli/cli_common_options.py
@@ -113,12 +113,20 @@ def common_all(fn):
             "runs with limited memory.",
         ),
         click.option(
-            "--no-interactive",
+            "--no-output",
             type=bool,
             is_flag=True,
             default=False,
-            help="Do not generate an interactive visualization. This speeds up runs, and "
-            "for runs with a large amount of BGCs, the interactive visualization can fail to load.",
+            help="Do not generate any output besides the data stored in the database. "
+            "Suitable for advanced users that work with the SQL database directly.",
+        ),
+        click.option(
+            "--no-trees",
+            type=bool,
+            is_flag=True,
+            default=False,
+            help="Do not generate any GCF newick trees. Suitable for users that do not "
+            "utilize our output visualization, but work with output tsv files directly.",
         ),
         click.option(
             "--force-gbk",

--- a/big_scape/output/legacy_output.py
+++ b/big_scape/output/legacy_output.py
@@ -164,7 +164,7 @@ def legacy_prepare_output(
     click_context = click.get_current_context(silent=True)
 
     if click_context and click_context.obj["db_only_output"]:
-        logging.info("Skipping all output generation")
+        logging.info("Skipping all (non-SQLite db related) output generation")
         return
 
     copy_base_output_templates(output_dir)

--- a/big_scape/output/legacy_output.py
+++ b/big_scape/output/legacy_output.py
@@ -262,7 +262,6 @@ def legacy_generate_bin_output(
     write_cutoff_network_file(run, cutoff, pair_generator)
 
     if click_context and click_context.obj["no_trees"]:
-        logging.info("Skipping GCF alignments and trees generation")
         return
 
     generate_newick_trees(run, cutoff, pair_generator, families_members)

--- a/big_scape/output/legacy_output.py
+++ b/big_scape/output/legacy_output.py
@@ -3,6 +3,7 @@
 # from python
 from itertools import repeat
 import json
+import logging
 from multiprocessing import Pool
 from distutils import dir_util
 from pathlib import Path
@@ -162,7 +163,8 @@ def legacy_prepare_output(
 
     click_context = click.get_current_context(silent=True)
 
-    if click_context and click_context.obj["no_interactive"]:
+    if click_context and click_context.obj["no_output"]:
+        logging.info("Skipping all output generation")
         return
 
     copy_base_output_templates(output_dir)
@@ -187,7 +189,7 @@ def legacy_prepare_cutoff_output(run: dict, cutoff: float, gbks: list[GBK]) -> N
 
     click_context = click.get_current_context(silent=True)
 
-    if click_context and click_context.obj["no_interactive"]:
+    if click_context and click_context.obj["no_output"]:
         return
 
     output_dir: Path = run["output_dir"]
@@ -213,7 +215,7 @@ def legacy_prepare_bin_output(
 
     click_context = click.get_current_context(silent=True)
 
-    if click_context and click_context.obj["no_interactive"]:
+    if click_context and click_context.obj["no_output"]:
         return
 
     output_dir: Path = run["output_dir"]
@@ -224,6 +226,9 @@ def legacy_prepare_bin_output(
     cutoff_files_path = output_files_root / f"{label}_c{cutoff}"
     pair_generator_files_path = cutoff_files_path / pair_generator.label
     pair_generator_files_path.mkdir(exist_ok=True)
+
+    if click_context and click_context.obj["no_trees"]:
+        return
 
     tree_path = pair_generator_files_path / Path("GCF_trees")
     tree_path.mkdir(exist_ok=True)
@@ -247,7 +252,7 @@ def legacy_generate_bin_output(
 
     click_context = click.get_current_context(silent=True)
 
-    if click_context and click_context.obj["no_interactive"]:
+    if click_context and click_context.obj["no_output"]:
         return
 
     families_members = generate_bs_families_members(
@@ -255,6 +260,11 @@ def legacy_generate_bin_output(
     )
     write_clustering_file(run, cutoff, pair_generator)
     write_cutoff_network_file(run, cutoff, pair_generator)
+
+    if click_context and click_context.obj["no_trees"]:
+        logging.info("Skipping GCF alignments and trees generation")
+        return
+
     generate_newick_trees(run, cutoff, pair_generator, families_members)
 
 
@@ -322,7 +332,7 @@ def write_record_annotations_file(run, cutoff, all_bgc_records) -> None:
 
     click_context = click.get_current_context(silent=True)
 
-    if click_context and click_context.obj["no_interactive"]:
+    if click_context and click_context.obj["no_output"]:
         return
 
     run_id = run["run_id"]
@@ -527,7 +537,7 @@ def write_full_network_file(run: dict, all_bgc_records: list[BGCRecord]) -> None
 
     click_context = click.get_current_context(silent=True)
 
-    if click_context and click_context.obj["no_interactive"]:
+    if click_context and click_context.obj["no_output"]:
         return
 
     output_dir = run["output_dir"]

--- a/big_scape/output/legacy_output.py
+++ b/big_scape/output/legacy_output.py
@@ -163,7 +163,7 @@ def legacy_prepare_output(
 
     click_context = click.get_current_context(silent=True)
 
-    if click_context and click_context.obj["no_output"]:
+    if click_context and click_context.obj["db_only_output"]:
         logging.info("Skipping all output generation")
         return
 
@@ -189,7 +189,7 @@ def legacy_prepare_cutoff_output(run: dict, cutoff: float, gbks: list[GBK]) -> N
 
     click_context = click.get_current_context(silent=True)
 
-    if click_context and click_context.obj["no_output"]:
+    if click_context and click_context.obj["db_only_output"]:
         return
 
     output_dir: Path = run["output_dir"]
@@ -215,7 +215,7 @@ def legacy_prepare_bin_output(
 
     click_context = click.get_current_context(silent=True)
 
-    if click_context and click_context.obj["no_output"]:
+    if click_context and click_context.obj["db_only_output"]:
         return
 
     output_dir: Path = run["output_dir"]
@@ -252,7 +252,7 @@ def legacy_generate_bin_output(
 
     click_context = click.get_current_context(silent=True)
 
-    if click_context and click_context.obj["no_output"]:
+    if click_context and click_context.obj["db_only_output"]:
         return
 
     families_members = generate_bs_families_members(
@@ -331,7 +331,7 @@ def write_record_annotations_file(run, cutoff, all_bgc_records) -> None:
 
     click_context = click.get_current_context(silent=True)
 
-    if click_context and click_context.obj["no_output"]:
+    if click_context and click_context.obj["db_only_output"]:
         return
 
     run_id = run["run_id"]
@@ -536,7 +536,7 @@ def write_full_network_file(run: dict, all_bgc_records: list[BGCRecord]) -> None
 
     click_context = click.get_current_context(silent=True)
 
-    if click_context and click_context.obj["no_output"]:
+    if click_context and click_context.obj["db_only_output"]:
         return
 
     output_dir = run["output_dir"]


### PR DESCRIPTION
Splits no-interactive into db-only-output and no-trees.

output folder with --db-only-ouput will contain .log files and the database (without newick GCF trees)
output folder with --no-trees will contain all html and output files except for the GCF_Trees folder (and no newick trees in the database)