### PR TITLE
add actual bin label to query bins

### DIFF
--- a/big_scape/distances/query.py
+++ b/big_scape/distances/query.py
@@ -44,7 +44,7 @@ def calculate_distances_query(
     edge_param_id = bs_comparison.get_edge_param_id(run, weights)
 
     query_bin = bs_comparison.QueryRecordPairGenerator(
-        "Query", edge_param_id, weights, run["record_type"]
+        weights, edge_param_id, weights, run["record_type"]
     )
     query_bin.add_records(query_records)
 
@@ -71,7 +71,7 @@ def calculate_distances_query(
     )
 
     query_bin_connected = bs_comparison.RecordPairGenerator(
-        "Query", edge_param_id, weights, record_type=run["record_type"]
+        weights, edge_param_id, weights, record_type=run["record_type"]
     )
     query_bin_connected.add_records(query_nodes)
 

--- a/big_scape/run_bigscape.py
+++ b/big_scape/run_bigscape.py
@@ -335,7 +335,7 @@ def run_bigscape(run: dict) -> None:
             )
 
             query_bin = bs_comparison.ConnectedComponentPairGenerator(
-                cc_cutoff[cutoff], "Query"
+                cc_cutoff[cutoff], query_bin.label
             )
             query_bin.add_records(
                 [record for record in query_records if record is not None]


### PR DESCRIPTION
output index.html has no knowledge of query bgc legacy class and relies on bin_label to select the correct edge_param_id when querying the distance table to construct bs_similarity -> cc fails to load when using --legacy_weights

- changes label from "Query" to either "mix" or the actual classify class/category e.g. "PKS"