### PR TITLE
fix reverse extend target index popping

### DIFF
--- a/big_scape/comparison/extend.py
+++ b/big_scape/comparison/extend.py
@@ -405,7 +405,7 @@ def score_extend(
         if not match_after_lcs:
             score += mismatch
 
-        if score > max_score:
+        if score >= max_score:
             max_score = score
             query_cds_idx = query_index[query_domain_start + hsp_idx]
             query_exp = query_cds_idx + 1 - query_start
@@ -498,8 +498,9 @@ def score_extend_rev(
             if domain_idx < last_domain_idx:
                 last_domain_idx = domain_idx
 
-            # remove the current target index from the index
-            target_index[hsp.domain].pop(dict_idx)
+            # remove the current target index from the index, reverse the dict_idx
+            # since we move through the target index domain lists in reverse
+            target_index[hsp.domain].pop(-dict_idx - 1)
 
             break
 
@@ -507,7 +508,7 @@ def score_extend_rev(
             score += mismatch
             continue
 
-        if score > max_score:
+        if score >= max_score:
             max_score = score
             query_cds_idx = query_index[query_domain_start - hsp_idx]
             query_exp = query_start - query_cds_idx

--- a/test/comparison/test_extend.py
+++ b/test/comparison/test_extend.py
@@ -629,7 +629,7 @@ class TestExtendLegacy(unittest.TestCase):
 
     def test_extend_forward_mid_cds_query_start(self):
         """Tests extend when starting in the middle of cds"""
-        q_domains = {2: ["X", "X"], 3: ["X", "Q"], 4: ["A", "B"], 5: ["C"]}
+        q_domains = {2: ["X", "X"], 3: ["X", "Q"], 4: ["A", "C"], 5: ["B"]}
         t_domains = {0: ["X"], 1: ["X", "X", "Q"], 2: ["A"], 3: ["B", "C"]}
         query_dom, target_dom = generate_mock_lcs_region(6, 5, q_domains, t_domains)
 
@@ -716,18 +716,18 @@ class TestExtendLegacy(unittest.TestCase):
 
     def test_extend_reverse_mid_cds_starts(self):
         """Tests extend when starting in the middle of cds"""
-        q_domains = {2: ["C"], 3: ["B", "A"], 4: ["Q", "X"], 5: ["X", "A"]}
-        t_domains = {0: ["B", "C"], 1: ["A"], 2: ["N", "Q", "X"], 3: ["X"]}
+        q_domains = {2: ["C"], 3: ["B", "A", "A"], 4: ["Q", "X"], 5: ["X"]}
+        t_domains = {0: ["B", "C"], 1: ["A"], 2: ["N", "Q", "X"], 3: ["X", "A"]}
         query_dom, target_dom = generate_mock_lcs_region(6, 5, q_domains, t_domains)
 
         target_index = bs_comp.extend.get_target_indexes(target_dom)
         query_index = bs_comp.extend.get_query_indexes(query_dom)
 
-        # four matches QABC, one gap: 4*5 - 2 = 18
-        expected_extends = (2, 4, 2, 5, 18)
+        # four matches QABC, one gap, one mismatch (extra A): 4*5 - 2 - 3 = 15
+        expected_extends = (2, 5, 2, 5, 15)
 
         actual_extends = bs_comp.extend.score_extend_rev(
-            query_dom, query_index, 2, 4, target_index, 2, 5, 5, -3, -2, 10
+            query_dom, query_index, 2, 5, target_index, 2, 5, 5, -3, -2, 10
         )
 
         self.assertEqual(expected_extends, actual_extends)


### PR DESCRIPTION
reverse target_index pop to account for the reverse traversal of the domain lists,
check if score is higher **or equal** to max_score in accordance with v1