### PR TITLE
clear central on new longest lcs

### DIFF
--- a/big_scape/cli/benchmark_cli.py
+++ b/big_scape/cli/benchmark_cli.py
@@ -52,11 +52,11 @@ def benchmark(ctx, *args, **kwargs):
     ctx.obj.update(ctx.params)
     ctx.obj["mode"] = "Benchmark"
 
-    # workflow validations
-    validate_output_paths(ctx)
-
     # set start time and label
     set_start(ctx.obj)
+
+    # workflow validations
+    validate_output_paths(ctx)
 
     # initialize logger
     init_logger(ctx.obj)

--- a/big_scape/cli/cli_validations.py
+++ b/big_scape/cli/cli_validations.py
@@ -7,7 +7,6 @@ import logging
 from pathlib import Path
 from typing import Optional
 import os
-import time
 import platform
 
 # from other modules

--- a/big_scape/cli/cli_validations.py
+++ b/big_scape/cli/cli_validations.py
@@ -22,7 +22,7 @@ def set_start(param_dict) -> None:
     """get start time and set label in a run parameter dict"""
 
     start_time: datetime = datetime.now()
-    timestamp = start_time.strftime("%d-%m-%Y_%H-%M-%S")
+    timestamp = start_time.strftime("%Y-%m-%d_%H-%M-%S")
     if param_dict["label"]:
         param_dict["label"] = f"{param_dict['label']}_{timestamp}"
     else:
@@ -116,7 +116,7 @@ def validate_output_dir(ctx, param, output_dir) -> Path:
 def validate_output_paths(ctx) -> None:
     """Sets the output paths to default output_dir if not provided"""
 
-    timestamp = time.strftime("%Y-%m-%d_%H-%M-%S", time.localtime())
+    timestamp = ctx.obj["label"]
 
     if "db_path" in ctx.obj and ctx.obj["db_path"] is None:
         db_path = ctx.obj["output_dir"] / Path(f"{ctx.obj['output_dir'].name}.db")

--- a/big_scape/cli/cluster_cli.py
+++ b/big_scape/cli/cluster_cli.py
@@ -138,15 +138,15 @@ def cluster(ctx, *args, **kwargs):
     ctx.obj["propagate"] = True  # compatibility with query wrt cc generation
     ctx.obj["mode"] = "Cluster"
 
+    # set start time and run label
+    set_start(ctx.obj)
+
     # workflow validations
     validate_binning_cluster_workflow(ctx)
     validate_pfam_path(ctx)
     validate_domain_include_list(ctx)
     validate_output_paths(ctx)
     validate_disk_only(ctx)
-
-    # set start time and run label
-    set_start(ctx.obj)
 
     # initialize logger
     init_logger(ctx.obj)

--- a/big_scape/cli/query_cli.py
+++ b/big_scape/cli/query_cli.py
@@ -99,15 +99,15 @@ def query(ctx, *args, **kwarg):
     ctx.obj["exclude_classes"] = None
     ctx.obj["include_classes"] = None
 
+    # set start time and label
+    set_start(ctx.obj)
+
     # workflow validations
     validate_pfam_path(ctx)
     validate_output_paths(ctx)
     validate_binning_query_workflow(ctx)
     validate_query_record(ctx)
     validate_disk_only(ctx)
-
-    # set start time and label
-    set_start(ctx.obj)
 
     # initialize logger
     init_logger(ctx.obj)

--- a/big_scape/comparison/lcs.py
+++ b/big_scape/comparison/lcs.py
@@ -287,7 +287,9 @@ def find_domain_lcs_region(
 
         # Length
 
-        # clear the lists if it's not empty and the current match is longer
+        # clear the longest list if it's not empty and the current match is longer.
+        # also clear the central list as we do not care about a shorter LCS even if it
+        # is more central
         if len(use_longest_list) > 0 and length > use_longest_list[0][1]:
             use_longest_list.clear()
             use_central_list.clear()
@@ -524,7 +526,9 @@ def find_domain_lcs_protocluster(
 
         # Length
 
-        # clear the lists if it's not empty and the current match is longer
+        # clear the longest list if it's not empty and the current match is longer.
+        # also clear the central list as we do not care about a shorter LCS even if it
+        # is more central
         if len(use_longest_list) > 0 and length > use_longest_list[0][1]:
             use_longest_list.clear()
             use_central_list.clear()

--- a/big_scape/comparison/lcs.py
+++ b/big_scape/comparison/lcs.py
@@ -287,9 +287,10 @@ def find_domain_lcs_region(
 
         # Length
 
-        # clear the list if it's not empty and the current match is longer
+        # clear the lists if it's not empty and the current match is longer
         if len(use_longest_list) > 0 and length > use_longest_list[0][1]:
             use_longest_list.clear()
+            use_central_list.clear()
 
         # add the match to the list if it's empty or the current match is equal length
         # or longer than the existing match
@@ -523,9 +524,10 @@ def find_domain_lcs_protocluster(
 
         # Length
 
-        # clear the list if it's not empty and the current match is longer
+        # clear the lists if it's not empty and the current match is longer
         if len(use_longest_list) > 0 and length > use_longest_list[0][1]:
             use_longest_list.clear()
+            use_central_list.clear()
 
         # add the match to the list if it's empty or the current match is equal length
         # or longer than the existing match

--- a/big_scape/output/legacy_output.py
+++ b/big_scape/output/legacy_output.py
@@ -638,11 +638,13 @@ def write_network_file(
         .where(edge_params_table.c.weights.in_(incl_weights))
         .where(edge_params_table.c.alignment_mode == aln_mode)
         .where(edge_params_table.c.extend_strategy == ext_strat)
-        .where(distance_table.c.distance < 1)
     )
 
     if cutoff is not None:
         select_statement = select_statement.where(distance_table.c.distance < cutoff)
+    else:
+        # still do not include edges with a distance of 1
+        select_statement = select_statement.where(distance_table.c.distance < 1)
 
     edgelist = set(DB.execute(select_statement).fetchall())
 

--- a/big_scape/output/legacy_output.py
+++ b/big_scape/output/legacy_output.py
@@ -638,6 +638,7 @@ def write_network_file(
         .where(edge_params_table.c.weights.in_(incl_weights))
         .where(edge_params_table.c.alignment_mode == aln_mode)
         .where(edge_params_table.c.extend_strategy == ext_strat)
+        .where(distance_table.c.distance < 1)
     )
 
     if cutoff is not None:


### PR DESCRIPTION
Clear central LCS list when encountering a new longest LCS. Prevents choosing the wrong LCS when there are multiple longest LCS with the same distance to the middle, along with a shorter LCS with the same distance to the middle.