### PR TITLE
split tests from badges workflow

### DIFF
--- a/.github/workflows/badges.yml
+++ b/.github/workflows/badges.yml
@@ -5,34 +5,6 @@ on:
     branches:
       - master
 
-jobs:
-  run_pytest:
-    runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.head_commit.message, 'docs') && !contains(github.event.head_commit.message, 'documentation')  }}
-    timeout-minutes: 15
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v3
-
-    - name: Set up mamba environment
-      uses: mamba-org/setup-micromamba@v1
-      with:
-        micromamba-version: '1.3.1-0'
-        environment-file: environment.yml
-        environment-name: BiG-SCAPE
-        init-shell: bash
-        generate-run-shell: true
-
-    - name: Install dependencies
-      shell: micromamba-shell {0}
-      run: |
-        python -m pip install pytest
-
-    - name: Test with Pytest
-      shell: micromamba-shell {0}
-      run: |
-        pytest
-
   generate_coverage:
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.head_commit.message, 'docs') && !contains(github.event.head_commit.message, 'documentation')  }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -6,6 +6,8 @@ on:
       - master
       - dev
       - release/*
+      - feature/*
+      - hotfix/*
 
 jobs:
   run_pytest:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,36 @@
+name: Run tests
+
+on:
+  push:
+    branches:
+      - master
+      - dev
+      - release/*
+
+jobs:
+  run_pytest:
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.head_commit.message, 'docs') && !contains(github.event.head_commit.message, 'documentation')  }}
+    timeout-minutes: 15
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Set up mamba environment
+      uses: mamba-org/setup-micromamba@v1
+      with:
+        micromamba-version: '1.3.1-0'
+        environment-file: environment.yml
+        environment-name: BiG-SCAPE
+        init-shell: bash
+        generate-run-shell: true
+
+    - name: Install dependencies
+      shell: micromamba-shell {0}
+      run: |
+        python -m pip install pytest
+
+    - name: Test with Pytest
+      shell: micromamba-shell {0}
+      run: |
+        pytest


### PR DESCRIPTION
This will do a pytest run for pushes on master, dev, release*, hotfix* and feature* branches. Probably it should be even less limited but for now this is fine.