### PR TITLE
Add temporary tables for GBK file hashes and GBK ids

### DIFF
--- a/big_scape/genbank/proto_cluster.py
+++ b/big_scape/genbank/proto_cluster.py
@@ -7,6 +7,7 @@ from typing import Dict, Optional, TYPE_CHECKING
 
 # from dependencies
 from Bio.SeqFeature import SeqFeature
+from sqlalchemy import Table, select
 
 # from other modules
 from big_scape.data import DB
@@ -179,7 +180,10 @@ class ProtoCluster(BGCRecord):
         return f"{self.parent_gbk} ProtoCluster {self.number} {self.nt_start}-{self.nt_stop} "
 
     @staticmethod
-    def load_all(candidate_cluster_dict: dict[int, CandidateCluster]):
+    def load_all(
+        candidate_cluster_dict: dict[int, CandidateCluster],
+        temp_gbk_id_table: Table = None,
+    ):
         """Load all ProtoCluster objects from the database
 
         This function populates the CandidateCluster objects in the GBKs provided in the
@@ -210,9 +214,14 @@ class ProtoCluster(BGCRecord):
                 record_table.c.merged,
             )
             .where(record_table.c.record_type == "protocluster")
-            .where(record_table.c.parent_id.in_(candidate_cluster_dict.keys()))
-            .compile()
         )
+
+        if temp_gbk_id_table is not None:
+            protocluster_select_query = protocluster_select_query.where(
+                record_table.c.gbk_id.in_(select(temp_gbk_id_table.c.gbk_id))
+            )
+
+        protocluster_select_query = protocluster_select_query.compile()
 
         cursor_result = DB.execute(protocluster_select_query)
 


### PR DESCRIPTION
This creates two temporary tables during input parsing that are used in select statements instead of using a very very large where clause with a bunch of data.

We are using this table everywhere, but there is the option to omit it from load_many which does no filtering whatsoever. No idea what happens if we were to use that. (but we don't use it)