### PR TITLE
Hotfix/remove ref cc

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ For installation instructions, see [here](https://github.com/medema-group/BiG-SC
 Learn more about BiG-SCAPE in the [wiki](https://github.com/medema-group/BiG-SCAPE/wiki).
 
 
-![BiG-SCAPE workflow](Figures/BiG-SCAPE-CORASON_Fig1_20171122_v01_MM_nocorason.png)
+![BiG-SCAPE workflow](figures/BiG-SCAPE-CORASON_Fig1_20171122_v01_MM_nocorason.png)
 
 
 If you find BiG-SCAPE useful, please cite us:

--- a/big_scape/data/sqlite.py
+++ b/big_scape/data/sqlite.py
@@ -14,6 +14,7 @@ from sqlalchemy import (
     Compiled,
     Select,
     Insert,
+    Delete,
     CursorResult,
     create_engine,
     func,
@@ -283,7 +284,9 @@ class DB:
         return DB.connection.execute(text(query))
 
     @staticmethod
-    def execute(query: Compiled | Select[Any] | Insert, commit=True) -> CursorResult:
+    def execute(
+        query: Compiled | Select[Any] | Insert | Delete, commit=True
+    ) -> CursorResult:
         """Wrapper for SQLAlchemy.connection.execute expecting a Compiled query
 
         Arguments:

--- a/big_scape/distances/query.py
+++ b/big_scape/distances/query.py
@@ -67,7 +67,7 @@ def calculate_distances_query(
     query_nodes = bs_network.get_nodes_from_cc(query_connected_component, query_records)
 
     bs_network.remove_connected_component(
-        query_connected_component, max_cutoff, run["run_id"]
+        query_connected_component, query_bin.label, max_cutoff, run["run_id"]
     )
 
     query_bin_connected = bs_comparison.RecordPairGenerator(

--- a/big_scape/network/families.py
+++ b/big_scape/network/families.py
@@ -311,7 +311,7 @@ def run_family_assignments(
                     connected_component, bin.source_records
                 ):
                     bs_network.remove_connected_component(
-                        connected_component, cutoff, run["run_id"]
+                        connected_component, bin.label, cutoff, run["run_id"]
                     )
                     continue
 

--- a/test/integration/test_network.py
+++ b/test/integration/test_network.py
@@ -465,7 +465,7 @@ class TestComparison(TestCase):
                 cc, include_records
             )
             if is_ref_only:
-                bs_network.remove_connected_component(cc, 0.8, 1)
+                bs_network.remove_connected_component(cc, mix_bin.label, 0.8, 1)
 
         cc_table = bs_data.DB.metadata.tables["connected_component"]
 
@@ -488,7 +488,7 @@ class TestComparison(TestCase):
                 cc, include_records
             )
             if is_ref_only:
-                bs_network.remove_connected_component(cc, 0.5, 1)
+                bs_network.remove_connected_component(cc, mix_bin.label, 0.5, 1)
 
         cc_table = bs_data.DB.metadata.tables["connected_component"]
 

--- a/test/network/test_network.py
+++ b/test/network/test_network.py
@@ -463,7 +463,7 @@ class TestNetwork(TestCase):
 
         cc = next(bs_network.get_connected_components(0.5, 1, mix_bin, 1))
 
-        cc_id = bs_network.get_connected_component_id(cc, 0.5, 1)
+        cc_id = bs_network.get_connected_component_id(cc, mix_bin.label, 0.5, 1)
 
         expected_data = 1
 
@@ -528,7 +528,7 @@ class TestNetwork(TestCase):
                 cc, include_records
             )
             if is_ref_only:
-                bs_network.remove_connected_component(cc, 0.5, 1)
+                bs_network.remove_connected_component(cc, mix_bin.label, 0.5, 1)
 
         select_statement = select(cc_table.c.id).distinct()
 


### PR DESCRIPTION
Makes sure reference-only connected components are correctly removed from the database based on bin_label,
Relevant in cases where both mix and classify are ran.