### PR TITLE
Hotfix/cand cluster category

### DIFF
--- a/big_scape/cli/cli_common_options.py
+++ b/big_scape/cli/cli_common_options.py
@@ -109,7 +109,11 @@ def common_cluster_query(fn):
                 exists=True, file_okay=False, dir_okay=True, path_type=Path
             ),
             required=True,
-            help="Input directory containing .gbk files to be used by BiG-SCAPE. See the wiki for more details.",
+            help=(
+                "Input directory containing .gbk files to be used by BiG-SCAPE. "
+                "Duplicated filenames can be handled, but are not recommended. "
+                "See the wiki for more details."
+            ),
         ),
         click.option(
             "--config-file-path",
@@ -139,6 +143,7 @@ def common_cluster_query(fn):
             help=(
                 "Tells BiG-SCAPE where to look for input GBK files. "
                 "recursive: search for .gbk files recursively in input directory. "
+                "Duplicated filenames are not recommended. "
                 "flat: search for .gbk files in input directory only. "
                 "(default: recursive)."
             ),
@@ -168,7 +173,8 @@ def common_cluster_query(fn):
                 exists=True, file_okay=False, dir_okay=True, path_type=Path
             ),
             help=(
-                "Path to directory containing user defined, non-MIBiG, antiSMASH processed reference BGCs."
+                "Path to directory containing user defined, non-MIBiG, antiSMASH processed reference BGCs. "
+                "Duplicated filenames are not recommended. "
                 "For more information, see the wiki."
             ),
         ),

--- a/big_scape/comparison/__init__.py
+++ b/big_scape/comparison/__init__.py
@@ -11,7 +11,6 @@ from .binning import (
     legacy_get_class,
     as_class_bin_generator,
     get_legacy_weights_from_category,
-    get_record_category,
 )
 from .comparable_region import ComparableRegion
 from .workflow import generate_edges
@@ -41,7 +40,6 @@ __all__ = [
     "legacy_get_class",
     "as_class_bin_generator",
     "get_legacy_weights_from_category",
-    "get_record_category",
     "save_edge_to_db",
     "save_edges_to_db",
     "lcs",

--- a/big_scape/distances/query.py
+++ b/big_scape/distances/query.py
@@ -82,7 +82,9 @@ def calculate_distances_query(
     return query_bin_connected
 
 
-def get_query_records(run, all_bgc_records, query_record) -> list[bs_gbk.BGCRecord]:
+def get_query_records(
+    run: dict, all_bgc_records: list[bs_gbk.BGCRecord], query_record: bs_gbk.BGCRecord
+) -> list[bs_gbk.BGCRecord]:
     """returns the query records and checks if the query is a singleton
 
     Args:
@@ -130,8 +132,8 @@ def get_query_records(run, all_bgc_records, query_record) -> list[bs_gbk.BGCReco
                     query_records.append(record)
 
             if classify_mode == bs_enums.CLASSIFY_MODE.CATEGORY:
-                query_category = [bs_comparison.get_record_category(query_record)]
-                record_category = [bs_comparison.get_record_category(record)]
+                query_category = [query_record.get_category()]
+                record_category = [record.get_category()]
 
                 intersect_cats = list(set(query_category) & set(record_category))
                 if len(intersect_cats) > 0:

--- a/big_scape/genbank/bgc_record.py
+++ b/big_scape/genbank/bgc_record.py
@@ -192,15 +192,15 @@ class BGCRecord:
                 break
         return record_start, record_stop
 
-    def set_record_category(self, categories: set[str]) -> None:
+    def set_record_category(self) -> None:
         """Sets the category of a record to categories in this record and its subrecords
 
         Relevant for regions and candidate clusters. Protocluster and protocore category
         is set during parsing of their feature, since they have only one category.
-
-        Args:
-            categories (set[str]): set of unique categories occuring in (sub)records
         """
+        # obtain categories present in any sub-records
+        categories = self.get_categories()
+
         if len(categories) == 0:
             # if no categories given, category remains None
             return

--- a/big_scape/genbank/bgc_record.py
+++ b/big_scape/genbank/bgc_record.py
@@ -53,6 +53,7 @@ class BGCRecord:
         nt_stop: int,
         contig_edge: Optional[bool],
         product: str,
+        category: Optional[str] = None,
     ):
         self.parent_gbk = parent_gbk
         self.number = number
@@ -61,6 +62,7 @@ class BGCRecord:
         self.nt_start = nt_start
         self.nt_stop = nt_stop
         self.product = product
+        self.category = category
         self.merged: bool = False
 
         # for database operations
@@ -189,6 +191,42 @@ class BGCRecord:
                 record_stop = idx
                 break
         return record_start, record_stop
+
+    def set_record_category(self, categories: set[str]) -> None:
+        """Sets the category of a record to categories in this record and its subrecords
+
+        Relevant for regions and candidate clusters. Protocluster and protocore category
+        is set during parsing of their feature, since they have only one category.
+
+        Args:
+            categories (set[str]): set of unique categories occuring in (sub)records
+        """
+        if len(categories) == 0:
+            # if no categories given, category remains None
+            return
+        elif len(categories) == 1:
+            category = list(categories)[0]
+        else:
+            category = ".".join(sorted(categories))
+        self.category = category
+
+    def get_categories(self) -> set[str]:
+        """Obtain a set of unique categories associated with this record
+
+        Semi-template method, overwritten by Region and CandidateCluster classes.
+        Returns an empty set if no categories are associated.
+        """
+        return set(self.category.split(".") if self.category is not None else [])
+
+    def get_category(self) -> str:
+        """Returns the category of a record or 'Categoryless' if category is None
+
+        Should be used instead of directly accessing the category attribute
+        to ensure compatibility with as5 and below, as well as --force-gbk
+        """
+        if self.category is not None:
+            return self.category
+        return "Categoryless"
 
     def save_record(
         self, record_type: str, parent_id: Optional[int] = None, commit=True

--- a/big_scape/genbank/gbk.py
+++ b/big_scape/genbank/gbk.py
@@ -707,10 +707,10 @@ class GBK:
                 cand_cluster.add_proto_cluster(
                     updated_tmp_proto_clusters[proto_cluster_num]
                 )
-            cand_cluster.set_record_category(cand_cluster.get_categories())
+            cand_cluster.set_record_category()
             region.add_cand_cluster(cand_cluster)
 
-        region.set_record_category(region.get_categories())
+        region.set_record_category()
 
         del (
             tmp_proto_clusters,

--- a/big_scape/genbank/gbk.py
+++ b/big_scape/genbank/gbk.py
@@ -626,9 +626,9 @@ class GBK:
             InvalidGBKError: Invalid or missing fields in gbk record
         """
 
-        tmp_cand_clusters = {}
-        tmp_proto_clusters = {}
-        tmp_proto_cores = {}
+        tmp_cand_clusters: dict[int, CandidateCluster] = {}
+        tmp_proto_clusters: dict[int, ProtoCluster] = {}
+        tmp_proto_cores: dict[int, ProtoCore] = {}
 
         # go through features, load into tmp dicts indexed by feature number
         orf_num = 1
@@ -707,8 +707,10 @@ class GBK:
                 cand_cluster.add_proto_cluster(
                     updated_tmp_proto_clusters[proto_cluster_num]
                 )
-
+            cand_cluster.set_record_category(cand_cluster.get_categories())
             region.add_cand_cluster(cand_cluster)
+
+        region.set_record_category(region.get_categories())
 
         del (
             tmp_proto_clusters,

--- a/big_scape/genbank/proto_cluster.py
+++ b/big_scape/genbank/proto_cluster.py
@@ -61,8 +61,8 @@ class ProtoCluster(BGCRecord):
             nt_stop,
             contig_edge,
             product,
+            category,
         )
-        self.category: Optional[str] = category
         self.proto_core: Dict[int, Optional[ProtoCore]] = proto_core
         self.proto_core_cds_idx: set[int] = set()
 

--- a/big_scape/genbank/proto_core.py
+++ b/big_scape/genbank/proto_core.py
@@ -55,9 +55,8 @@ class ProtoCore(BGCRecord):
             nt_stop,
             contig_edge,
             product,
+            category,
         )
-
-        self.category: Optional[str] = category
 
     def save(self, parent_id: int, commit=True) -> None:
         """Stores this protocore in the database

--- a/big_scape/output/html_template/output/index.html
+++ b/big_scape/output/html_template/output/index.html
@@ -1617,7 +1617,7 @@ CC\tFamily\tGBK\tRecord_Type\tRecord_Number\tClass\tCategory\tOrganism\tTaxonomy
     }
 
     function downloadAbPresTsv() {
-        sendDownload(document.getElementById("abpres_tsv_text"), "absence_presence.tsv")
+        sendDownload(document.getElementById("abpres_tsv_text").value, "absence_presence.tsv")
     }
 
     function sendDownload(content, filename) {

--- a/big_scape/output/legacy_output.py
+++ b/big_scape/output/legacy_output.py
@@ -17,7 +17,7 @@ from big_scape.data import DB
 from big_scape.comparison import RecordPairGenerator
 from big_scape.genbank import GBK, BGCRecord, CandidateCluster, ProtoCluster, ProtoCore
 from big_scape.trees import generate_newick_tree, save_trees
-from big_scape.comparison import lcs, get_record_category
+from big_scape.comparison import lcs
 
 import big_scape.paths as bs_paths
 import big_scape.enums as bs_enums
@@ -350,7 +350,7 @@ def write_record_annotations_file(run, cutoff, all_bgc_records) -> None:
 
     record_categories = {}
     for record in all_bgc_records:
-        record_categories[record._db_id] = get_record_category(record)
+        record_categories[record._db_id] = record.get_category()
 
     select_statement = (
         select(

--- a/big_scape/run_bigscape.py
+++ b/big_scape/run_bigscape.py
@@ -234,6 +234,8 @@ def run_bigscape(run: dict) -> None:
 
         bs_data.DB.commit()
 
+    bs_data.DB.save_to_disk(run["db_path"])
+
     # FAMILY GENERATION
     logging.info("Generating families")
 

--- a/big_scape/utility/filters.py
+++ b/big_scape/utility/filters.py
@@ -4,7 +4,6 @@ import logging
 
 # from other modules
 import big_scape.genbank as bs_gbk
-from big_scape.comparison import get_record_category
 
 
 def domain_includelist_filter(run: dict, all_bgc_records: list[bs_gbk.BGCRecord]):
@@ -91,7 +90,7 @@ def category_filter(
 
     filtered_bgc_records = []
     for record in all_bgc_records:
-        record_categs = set(get_record_category(record).split("."))
+        record_categs = record.get_categories()
         if generic_category_class_filter(record_categs, include_categs, exclude_categs):
             filtered_bgc_records.append(record)
 

--- a/test/comparison/test_binning.py
+++ b/test/comparison/test_binning.py
@@ -15,7 +15,6 @@ from big_scape.comparison import (
     RecordPairGenerator,
     ConnectedComponentPairGenerator,
     QueryRecordPairGenerator,
-    get_record_category,
     get_legacy_weights_from_category,
     as_class_bin_generator,
 )
@@ -622,8 +621,9 @@ class TestBinGenerators(TestCase):
 
         region = mock_region()
         cc = region.cand_clusters[1]
+        cc.set_record_category(cc.get_categories())
 
-        self.assertEqual("PKS", get_record_category(cc))
+        self.assertEqual("PKS", cc.get_category())
 
     def test_get_record_category_chemhybrid_pc1(self):
         gbk = create_mock_complete_chemhyb_gbk(
@@ -632,7 +632,7 @@ class TestBinGenerators(TestCase):
 
         pc_1 = gbk.region.cand_clusters[1].proto_clusters[1]
 
-        self.assertEqual("PKS", get_record_category(pc_1))
+        self.assertEqual("PKS", pc_1.get_category())
 
     def test_get_record_category_chemhybrid_pc2(self):
         gbk = create_mock_complete_chemhyb_gbk(
@@ -641,7 +641,7 @@ class TestBinGenerators(TestCase):
 
         pc_2 = gbk.region.cand_clusters[1].proto_clusters[2]
 
-        self.assertEqual("NRPS", get_record_category(pc_2))
+        self.assertEqual("NRPS", pc_2.get_category())
 
     def test_get_record_category_chemhybrid_cc(self):
         gbk = create_mock_complete_chemhyb_gbk(
@@ -649,9 +649,10 @@ class TestBinGenerators(TestCase):
         )
 
         cc = gbk.region.cand_clusters[1]
+        cc.set_record_category(cc.get_categories())
 
-        self.assertIn("PKS", get_record_category(cc))
-        self.assertIn("NRPS", get_record_category(cc))
+        self.assertIn("PKS", cc.get_category())
+        self.assertIn("NRPS", cc.get_category())
 
     def test_get_legacy_weight_from_category(self):
         """Tests wether the correct legacy weight category is created from a region category"""

--- a/test/comparison/test_binning.py
+++ b/test/comparison/test_binning.py
@@ -621,7 +621,7 @@ class TestBinGenerators(TestCase):
 
         region = mock_region()
         cc = region.cand_clusters[1]
-        cc.set_record_category(cc.get_categories())
+        cc.set_record_category()
 
         self.assertEqual("PKS", cc.get_category())
 
@@ -649,7 +649,7 @@ class TestBinGenerators(TestCase):
         )
 
         cc = gbk.region.cand_clusters[1]
-        cc.set_record_category(cc.get_categories())
+        cc.set_record_category()
 
         self.assertIn("PKS", cc.get_category())
         self.assertIn("NRPS", cc.get_category())

--- a/test/genbank/test_region.py
+++ b/test/genbank/test_region.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from Bio.SeqFeature import SeqFeature, FeatureLocation
 
 # from other modules
-from big_scape.genbank import Region, CandidateCluster, GBK
+from big_scape.genbank import Region, CandidateCluster, ProtoCluster, ProtoCore, GBK
 from big_scape.errors import InvalidGBKError
 from big_scape.data import DB
 from big_scape.enums import SOURCE_TYPE
@@ -187,3 +187,71 @@ class TestRegion(TestCase):
         actual_row_count = len(cursor_result.fetchall())
 
         self.assertEqual(expected_row_count, actual_row_count)
+
+    def test_set_record_category(self):
+        """Tests whether region category is set correctly"""
+        core = ProtoCore(None, 1, 0, 100, False, "T1PKS", "PKS")
+        pclust1 = ProtoCluster(None, 1, 0, 100, False, "T1PKS", {1: core}, "PKS")
+        pclust2 = ProtoCluster(None, 2, 200, 300, False, "NRPS", {}, "NRPS")
+        cand_cluster = CandidateCluster(
+            None, 1, 0, 100, False, "T1PKS.NRPS", "", {1: pclust1, 2: pclust2}
+        )
+        # set cand_cluster category, based on protocluster categories
+        cand_cluster.set_record_category(cand_cluster.get_categories())
+        self.assertEqual(cand_cluster.get_category(), "NRPS.PKS")
+
+        region = Region(None, 1, 0, 1000, False, "T1PKS.NRPS")
+        region.cand_clusters = {1: cand_cluster}
+
+        # region category is None, but can be fetched from cand_cluster
+        cats = region.get_categories()
+        self.assertIsNone(region.category)
+        self.assertEqual(set(["PKS", "NRPS"]), cats)
+
+        # after setting region category is equal to its cand_cluster
+        region.set_record_category(cats)
+        self.assertEqual(region.get_category(), "NRPS.PKS")
+
+    def test_get_category(self):
+        """Tests whether a Region category is correctly fetched"""
+        region_nrps = Region(None, 1, 0, 100, None, "NRPS", "NRPS")
+
+        self.assertEqual("NRPS", region_nrps.get_category())
+
+        region_none = Region(None, 1, 0, 100, None, "other", None)
+
+        self.assertEqual("Categoryless", region_none.get_category())
+
+        region_categoryless = Region(None, 1, 0, 10, None, "", "Categoryless")
+
+        self.assertEqual("Categoryless", region_categoryless.get_category())
+
+    def test_as5_set_and_get_category(self):
+        """Tests whether category is correctly set and read in as5 region"""
+        # AS5 does not have categories
+        core = ProtoCore(None, 1, 0, 100, False, "T1PKS")
+        pclust1 = ProtoCluster(None, 1, 0, 100, False, "T1PKS", {1: core})
+        pclust2 = ProtoCluster(None, 2, 200, 300, False, "NRPS", {})
+        cand_cluster = CandidateCluster(
+            None, 1, 0, 100, False, "T1PKS.NRPS", "", {1: pclust1, 2: pclust2}
+        )
+        region = Region(None, 1, 0, 1000, False, "T1PKS.NRPS")
+        region.cand_clusters = {1: cand_cluster}
+
+        # no categories in the region
+        cats = region.get_categories()
+        self.assertEqual(set([]), cats)
+
+        # after setting, category should remain None
+        region.set_record_category(cats)
+        self.assertIsNone(region.category)
+        self.assertEqual(region.get_category(), "Categoryless")
+
+    def test_as4_set_and_get_category(self):
+        """Tests whether category is correctly read in as4 region"""
+        # AS4 does not have categories and there are no protoclusters to access
+        as4_region = Region(None, 1, 0, 100, None, "other")
+
+        self.assertEqual(as4_region.get_categories(), set([]))
+        self.assertIsNone(as4_region.category)
+        self.assertEqual(as4_region.get_category(), "Categoryless")

--- a/test/genbank/test_region.py
+++ b/test/genbank/test_region.py
@@ -197,7 +197,7 @@ class TestRegion(TestCase):
             None, 1, 0, 100, False, "T1PKS.NRPS", "", {1: pclust1, 2: pclust2}
         )
         # set cand_cluster category, based on protocluster categories
-        cand_cluster.set_record_category(cand_cluster.get_categories())
+        cand_cluster.set_record_category()
         self.assertEqual(cand_cluster.get_category(), "NRPS.PKS")
 
         region = Region(None, 1, 0, 1000, False, "T1PKS.NRPS")
@@ -209,7 +209,7 @@ class TestRegion(TestCase):
         self.assertEqual(set(["PKS", "NRPS"]), cats)
 
         # after setting region category is equal to its cand_cluster
-        region.set_record_category(cats)
+        region.set_record_category()
         self.assertEqual(region.get_category(), "NRPS.PKS")
 
     def test_get_category(self):
@@ -243,7 +243,7 @@ class TestRegion(TestCase):
         self.assertEqual(set([]), cats)
 
         # after setting, category should remain None
-        region.set_record_category(cats)
+        region.set_record_category()
         self.assertIsNone(region.category)
         self.assertEqual(region.get_category(), "Categoryless")
 

--- a/test/integration/test_comparison.py
+++ b/test/integration/test_comparison.py
@@ -114,6 +114,9 @@ def create_mock_complete_single_gbk(
     candidate_cluster.add_proto_cluster(protocluster)
     region.add_cand_cluster(candidate_cluster)
 
+    candidate_cluster.set_record_category(candidate_cluster.get_categories())
+    region.set_record_category(region.get_categories())
+
     cds = CDS(0, 100)
     cds.parent_gbk = gbk
     cds.orf_num = 1

--- a/test/integration/test_comparison.py
+++ b/test/integration/test_comparison.py
@@ -114,8 +114,8 @@ def create_mock_complete_single_gbk(
     candidate_cluster.add_proto_cluster(protocluster)
     region.add_cand_cluster(candidate_cluster)
 
-    candidate_cluster.set_record_category(candidate_cluster.get_categories())
-    region.set_record_category(region.get_categories())
+    candidate_cluster.set_record_category()
+    region.set_record_category()
 
     cds = CDS(0, 100)
     cds.parent_gbk = gbk


### PR DESCRIPTION
Refactors setting and getting of record categories:
- moves the 'category' attribute to the general BGCRecord class
- Region and Cand_cluster category is set during parsing, based on child protoclusters
- Any 'Categoryless' records will have category=None, a category should always be fetched using the get_category method

small misc fixes:
- fixes broken absence_presence UI download
- small updates to help message
- extra DB save after distance calculation