### PR TITLE
Hotfix/reformat tsv

### DIFF
--- a/big_scape/distances/classify.py
+++ b/big_scape/distances/classify.py
@@ -66,7 +66,7 @@ def calculate_distances_classify(
                     callback,
                 )
 
-            bs_comparison.save_edges_to_db(save_batch)
+            bs_comparison.save_edges_to_db(save_batch, commit=True)
 
             bs_data.DB.commit()
 

--- a/big_scape/distances/legacy_classify.py
+++ b/big_scape/distances/legacy_classify.py
@@ -65,7 +65,7 @@ def calculate_distances_legacy_classify(
                     callback,
                 )
 
-            bs_comparison.save_edges_to_db(save_batch)
+            bs_comparison.save_edges_to_db(save_batch, commit=True)
 
             bs_data.DB.commit()
 

--- a/big_scape/distances/mix.py
+++ b/big_scape/distances/mix.py
@@ -62,8 +62,7 @@ def calculate_distances_mix(
                 run["cores"] * 2,
                 callback,
             )
-
-        bs_comparison.save_edges_to_db(save_batch)
+        bs_comparison.save_edges_to_db(save_batch, commit=True)
 
         bs_data.DB.commit()
 

--- a/big_scape/distances/query.py
+++ b/big_scape/distances/query.py
@@ -199,7 +199,7 @@ def calculate_distances(run: dict, bin: bs_comparison.RecordPairGenerator):
                     callback,
                 )
 
-            bs_comparison.save_edges_to_db(save_batch)
+            bs_comparison.save_edges_to_db(save_batch, commit=True)
 
             bs_data.DB.commit()
 

--- a/big_scape/output/legacy_output.py
+++ b/big_scape/output/legacy_output.py
@@ -375,10 +375,10 @@ def write_record_annotations_file(run, cutoff, all_bgc_records) -> None:
     with open(record_annotations_path, "w") as record_annotations_file:
         header = "\t".join(
             [
+                "Record",
                 "GBK",
                 "Record_Type",
                 "Record_Number",
-                "Full_Name",
                 "Class",
                 "Category",
                 "Organism",
@@ -402,10 +402,10 @@ def write_record_annotations_file(run, cutoff, all_bgc_records) -> None:
 
             row = "\t".join(
                 [
+                    f"{Path(gbk_path).name}_{record_type}_{record_number}",
                     Path(gbk_path).stem,
                     record_type,
                     str(record_number),
-                    f"{Path(gbk_path).name}_{record_type}_{record_number}",
                     product,
                     record_categories[rec_id],
                     organism,
@@ -477,7 +477,7 @@ def write_clustering_file(run, cutoff, pair_generator) -> None:
 
     with open(clustering_file_path, "w") as clustering_file:
         header = "\t".join(
-            ["GBK", "Record_Type", "Record_Number", "CC", "Family", "Full_Name"]
+            ["Record", "GBK", "Record_Type", "Record_Number", "CC", "Family"]
         )
         clustering_file.write(header + "\n")
 
@@ -486,12 +486,12 @@ def write_clustering_file(run, cutoff, pair_generator) -> None:
 
             row = "\t".join(
                 [
+                    f"{Path(gbk_path).name}_{record_type}_{record_number}",
                     Path(gbk_path).stem,
                     record_type,
                     str(record_number),
                     str(cc_number),
                     f"FAM_{family:0>5}",
-                    f"{Path(gbk_path).name}_{record_type}_{record_number}",
                 ]
             )
             clustering_file.write(row + "\n")
@@ -662,9 +662,9 @@ def write_network_file(
 
     with open(output_path, "w") as network_file:
         header = (
-            "GBK_a\tRecord_Type_a\tRecord_Number_a\tFull_Name_a\tORF_coords_a\tGBK_b\t"
-            "Record_Type_b\tRecord_Number_b\tFull_Name_b\tORF_coords_b\tdistance\t"
-            "jaccard\tadjacency\tdss\tweights\taligmnent_mode\textend_strategy\n"
+            "Record_a\tGBK_a\tRecord_Type_a\tRecord_Number_a\tORF_coords_a\t"
+            "Record_b\tGBK_b\tRecord_Type_b\tRecord_Number_b\tORF_coords_b\tdistance\t"
+            "jaccard\tadjacency\tdss\tweights\talignment_mode\textend_strategy\n"
         )
 
         network_file.write(header)
@@ -690,15 +690,15 @@ def write_network_file(
         ) in edgelist:
             row = "\t".join(
                 [
+                    f"{Path(gbk_path_a).name}_{record_type_a}_{record_number_a}",
                     Path(gbk_path_a).stem,
                     record_type_a,
                     str(record_number_a),
-                    f"{Path(gbk_path_a).name}_{record_type_a}_{record_number_a}",
                     f"{ext_a_start}:{ext_a_stop}",
+                    f"{Path(gbk_path_b).name}_{record_type_b}_{record_number_b}",
                     Path(gbk_path_b).stem,
                     record_type_b,
                     str(record_number_b),
-                    f"{Path(gbk_path_b).name}_{record_type_b}_{record_number_b}",
                     f"{ext_b_start}:{ext_b_stop}",
                     f"{distance:.2f}",
                     f"{jaccard:.2f}",
@@ -745,8 +745,8 @@ def write_topolink_file(bgc_records: list[BGCRecord], output_path: Path) -> None
 
     with open(output_path, "w") as topolink_file:
         header = (
-            "GBK_a\tRecord_Type_a\tRecord_Number_a\tFull_Name_a\tGBK_b\t"
-            "Record_Type_b\tRecord_Number_b\tFull_Name_b\tType\n"
+            "Record_a\tGBK_a\tRecord_Type_a\tRecord_Number_a\t"
+            "Record_b\tGBK_b\tRecord_Type_b\tRecord_Number_b\tType\n"
         )
         topolink_file.write(header)
         for parent, records in parent_dict.items():
@@ -757,14 +757,14 @@ def write_topolink_file(bgc_records: list[BGCRecord], output_path: Path) -> None
 
                     row = "\t".join(
                         [
+                            f"{parent.path.name}_{type_a}_{rec_a.number}",
                             parent.path.stem,
                             type_a,
                             str(rec_a.number),
-                            f"{parent.path.name}_{type_a}_{rec_a.number}",
+                            f"{parent.path.name}_{type_b}_{rec_b.number}",
                             parent.path.stem,
                             type_b,
                             str(rec_b.number),
-                            f"{parent.path.name}_{type_b}_{rec_b.number}",
                             "Topology",
                         ]
                     )

--- a/test/benchmark/test_data_loading.py
+++ b/test/benchmark/test_data_loading.py
@@ -33,9 +33,9 @@ class TestBenchmarkData(TestCase):
     def test_curated_gcf_loading_long_format(self):
         """Tests the loading of long format curated GCF assignments, e.g. protoclusters"""
         expected_data = {
-            "AGCF01000001.1.cluster077_protocluster_1": "ectoine",
-            "CM001149.1.cluster003_protocluster_1": "ectoine",
-            "CM001149.1.cluster001_protocluster_1": "FAS",
+            "AGCF01000001.1.cluster077.gbk_protocluster_1": "ectoine",
+            "CM001149.1.cluster003.gbk_protocluster_1": "ectoine",
+            "CM001149.1.cluster001.gbk_protocluster_1": "FAS",
             "CM002177.1.cluster025": "FAS",
         }
         curated_path = Path("test/test_data/curated_gcfs/valid_protocluster_gcfs.tsv")
@@ -87,15 +87,15 @@ class TestBenchmarkData(TestCase):
 
         expected_data = {
             "0.5": {
-                "CM000578.1.cluster047_protocluster_1": "00072",
-                "CM000578.1.cluster038_protocluster_1": "00077",
-                "CM000578.1.cluster038_protocluster_2": "00179",
+                "CM000578.1.cluster047.gbk_protocluster_1": "00072",
+                "CM000578.1.cluster038.gbk_protocluster_1": "00077",
+                "CM000578.1.cluster038.gbk_protocluster_2": "00179",
                 "CM000578.1.cluster033": "00167",
             },
             "0.7": {
-                "CM000578.1.cluster038_protocluster_1": "00006",
-                "CM000578.1.cluster038_protocluster_2": "00006",
-                "CM000578.1.cluster042_protocluster_1_2": "00010",
+                "CM000578.1.cluster038.gbk_protocluster_1": "00006",
+                "CM000578.1.cluster038.gbk_protocluster_2": "00006",
+                "CM000578.1.cluster042.gbk_protocluster_1_2": "00010",
                 "CM000578.1.cluster033": "00062",
             },
         }

--- a/test/test_data/bs2_output/2023-12-07_12-15-35_c0.5/mix/mix_clustering_c0.5.tsv
+++ b/test/test_data/bs2_output/2023-12-07_12-15-35_c0.5/mix/mix_clustering_c0.5.tsv
@@ -1,5 +1,5 @@
-GBK	Record_Type	Record_Number	CC	Family
-../data/benchmark_antismash_files/extracted/Fusarium/Fusarium_16/CM000578.1.cluster047.gbk	protocluster	1	1	FAM_00072
-../data/benchmark_antismash_files/extracted/Fusarium/Fusarium_108/CM000578.1.cluster038.gbk	protocluster	1	1	FAM_00077
-../data/benchmark_antismash_files/extracted/Fusarium/Fusarium_108/CM000578.1.cluster038.gbk	protocluster	2	1	FAM_00179
-../data/benchmark_antismash_files/extracted/Fusarium/Fusarium_75/CM000578.1.cluster033.gbk	region	33	1	FAM_00167
+Record	GBK	Record_Type	Record_Number	CC	Family
+CM000578.1.cluster047.gbk_protocluster_1	CM000578.1.cluster047	protocluster	1	1	FAM_00072
+CM000578.1.cluster038.gbk_protocluster_1	CM000578.1.cluster038	protocluster	1	1	FAM_00077
+CM000578.1.cluster038.gbk_protocluster_2	CM000578.1.cluster038	protocluster	2	1	FAM_00179
+CM000578.1.cluster033.gbk_region_33	CM000578.1.cluster033	region	33	1	FAM_00167

--- a/test/test_data/bs2_output/2023-12-07_12-15-35_c0.7/mix/mix_clustering_c0.7.tsv
+++ b/test/test_data/bs2_output/2023-12-07_12-15-35_c0.7/mix/mix_clustering_c0.7.tsv
@@ -1,5 +1,5 @@
-GBK	Record_Type	Record_Number	CC	Family
-../data/benchmark_antismash_files/extracted/Fusarium/Fusarium_108/CM000578.1.cluster038.gbk	protocluster	1	1	FAM_00006
-../data/benchmark_antismash_files/extracted/Fusarium/Fusarium_108/CM000578.1.cluster038.gbk	protocluster	2	1	FAM_00006
-../data/benchmark_antismash_files/extracted/Fusarium/Fusarium_19/CM000578.1.cluster042.gbk	protocluster	1_2	1	FAM_00010
-../data/benchmark_antismash_files/extracted/Fusarium/Fusarium_75/CM000578.1.cluster033.gbk	region	33	1	FAM_00062
+Record	GBK	Record_Type	Record_Number	CC	Family
+CM000578.1.cluster038.gbk_protocluster_1	CM000578.1.cluster038	protocluster	1	1	FAM_00006
+CM000578.1.cluster038.gbk_protocluster_2	CM000578.1.cluster038	protocluster	2	1	FAM_00006
+CM000578.1.cluster042.gbk_protocluster_1_2	CM000578.1.cluster042	protocluster	1_2	1	FAM_00010
+CM000578.1.cluster033.gbk_region_33	CM000578.1.cluster033	region	33	1	FAM_00062

--- a/test/test_data/curated_gcfs/valid_protocluster_gcfs.tsv
+++ b/test/test_data/curated_gcfs/valid_protocluster_gcfs.tsv
@@ -1,5 +1,5 @@
-BGC_filename	record_type	record_number	product(s)	GCF_number
-AGCF01000001.1.cluster077	protocluster	1	['ectoine']	ectoine
-CM001149.1.cluster003	protocluster	1	['ectoine']	ectoine
-CM001149.1.cluster001	protocluster	1	['fatty_acid']	FAS
-CM002177.1.cluster025	region	1	['fatty_acid']	FAS
+BGC	Family
+AGCF01000001.1.cluster077.gbk_protocluster_1	ectoine
+CM001149.1.cluster003.gbk_protocluster_1	ectoine
+CM001149.1.cluster001.gbk_protocluster_1	FAS
+CM002177.1.cluster025	FAS


### PR DESCRIPTION
Slightly adjusts output tsv formats;  "Full_name" is now "Record" / "Record_a" and will be the first column

With that, also adjusts parsing of said tsvs in the benchmark module. 
The recommended approach for curated GCF assignment files:
- Always two columns with a header: BGC and Family (column names do not matter)
- in case of regions BGC will be equal to the GBK name without .gbk extension, e.g. `JK1.region005`
- in case of other record types BGC will be `<GBK>.gbk_<recordtype>_<recordnumber>`, e.g. `JK1.region005.gbk_protocluster_1_2`
- (mimicking the long format, similar to the output files is still possible)

Also ensures that distances are always saved and committed to the database. 