### PR TITLE
clarify gbk parsing errors

### DIFF
--- a/big_scape/genbank/candidate_cluster.py
+++ b/big_scape/genbank/candidate_cluster.py
@@ -76,6 +76,9 @@ class CandidateCluster(BGCRecord):
         """
 
         if proto_cluster.number not in self.proto_clusters:
+            logging.error(
+                "Protocluster number does not match the number in the parent candidate cluster"
+            )
             raise InvalidGBKRegionChildError()
 
         self.proto_clusters[proto_cluster.number] = proto_cluster

--- a/big_scape/genbank/proto_cluster.py
+++ b/big_scape/genbank/proto_cluster.py
@@ -77,6 +77,9 @@ class ProtoCluster(BGCRecord):
         """
 
         if proto_core.number not in self.proto_core:
+            logging.error(
+                "Protocore number does not match the number in the parent protocluster"
+            )
             raise InvalidGBKRegionChildError()
 
         proto_core.category = self.category

--- a/big_scape/genbank/region.py
+++ b/big_scape/genbank/region.py
@@ -74,6 +74,9 @@ class Region(BGCRecord):
         """
 
         if cand_cluster.number not in self.cand_clusters:
+            logging.error(
+                "Candidate cluster number does not match the number in the parent region"
+            )
             raise InvalidGBKRegionChildError()
 
         self.cand_clusters[cand_cluster.number] = cand_cluster


### PR DESCRIPTION
Old behaviour: encountered errors emit error logs, starmap hangs, bigscape does not exit

New behaviour: encountered errors emit error logs, after parsing all GBKs, exit if any error were encountered. 
Also added new logging messages for each ChildRegion error call and an additional check to see if any QUERY GBKs were parsed.