### PR TITLE
Rename all instances of hmmscan to hmmsearch

### DIFF
--- a/big_scape/data/partial_task.py
+++ b/big_scape/data/partial_task.py
@@ -153,7 +153,7 @@ def get_hmm_data_state() -> bs_enums.HMM_TASK:
 
 
 def get_cds_to_scan(gbks: list[GBK]) -> list[CDS]:
-    """Find which cds within a list of GBK objects need to be scanned using hmmscan
+    """Find which cds within a list of GBK objects need to be scanned using hmmsearch
 
     Args:
         gbks (list[GBK]): List of GBKs

--- a/big_scape/hmm/__init__.py
+++ b/big_scape/hmm/__init__.py
@@ -1,8 +1,9 @@
-"""Contains code to execute hmmpress, hmmscan and hmmalign"""
+"""Contains code to execute hmmpress, hmmsearch and hmmalign"""
+
 from .hmmer import HMMer, cds_to_input_task, cds_batch_generator  # type: ignore
 from .hsp import HSP, HSPAlignment
 from .legacy_filter import legacy_filter_overlap
-from .hmmscan import run_hmmscan
+from .hmmsearch import run_hmmsearch
 from .hmmalign import run_hmmalign
 
 __all__ = [
@@ -12,6 +13,6 @@ __all__ = [
     "HSP",
     "HSPAlignment",
     "legacy_filter_overlap",
-    "run_hmmscan",
+    "run_hmmsearch",
     "run_hmmalign",
 ]

--- a/big_scape/hmm/hmmer.py
+++ b/big_scape/hmm/hmmer.py
@@ -1,5 +1,5 @@
 # type: ignore # mypy doesn't like pyhmmer
-"""Contains methods to press an input .hmm file into more optimal formats for hmmscan
+"""Contains methods to press an input .hmm file into more optimal formats for hmmsearch
 and hmmalign
 """
 
@@ -108,7 +108,7 @@ class HMMer:
         # create an index so we can quickly get profiles by accession
         HMMer.profile_index = gen_profile_index(HMMer.profiles)
 
-        # this pipeline is used to perform hmmscan and hmmalign in more memory efficient
+        # this pipeline is used to perform hmmsearch and hmmalign in more memory efficient
         # use cases. This pipeline functions as a wrapper for hmmsearch etc. and can be
         # used to pass arguments that you can otherwise pass to these functions
         HMMer.pipeline = Pipeline(
@@ -265,7 +265,7 @@ class HMMer:
         batch_size: Optional[int] = None,
         callback: Optional[Callable] = None,
     ) -> None:
-        """Runs hmmscan using pyhmmer in several subprocesses. Passes batches of input
+        """Runs hmmsearch using pyhmmer in several subprocesses. Passes batches of input
         cds list to the subprocesses in an attempt to optimize memory usage
 
         Args:
@@ -508,7 +508,7 @@ class HMMer:
             domain_hsp: HSP
             for hsp_idx, domain_hsp in enumerate(hsp_list):
                 # we can cut the alignment down to only the range of the domain as found
-                # in hmmscan to speed up the process
+                # in hmmsearch to speed up the process
                 # different versions of pyhmmer have a different starting offset that we may or may
                 # not need to apply.
 

--- a/big_scape/hmm/hmmsearch.py
+++ b/big_scape/hmm/hmmsearch.py
@@ -1,4 +1,4 @@
-"""Contains functions for running pyhmmer's hmmscan workflow."""
+"""Contains functions for running pyhmmer's hmmsearch workflow."""
 
 # from python
 from datetime import datetime
@@ -14,8 +14,8 @@ from big_scape.hmm import HMMer, HSP
 import big_scape.data as bs_data
 
 
-def run_hmmscan(run: dict[str, Any], gbks: list[Any], start_time: Any) -> None:
-    """Runs the hmmscan workflow
+def run_hmmsearch(run: dict[str, Any], gbks: list[Any], start_time: Any) -> None:
+    """Runs the hmmsearch workflow
 
     Args:
         run (dict): run parameters
@@ -44,7 +44,7 @@ def run_hmmscan(run: dict[str, Any], gbks: list[Any], start_time: Any) -> None:
             platform.system(),
             run["cores"],
         )
-        with tqdm.tqdm(unit="CDS", total=len(HMMer.profiles), desc="HMMSCAN") as t:
+        with tqdm.tqdm(unit="CDS", total=len(HMMer.profiles), desc="hmmsearch") as t:
             HMMer.hmmsearch_simple(
                 cds_to_scan,
                 domain_overlap_cutoff=BigscapeConfig.DOMAIN_OVERLAP_CUTOFF,
@@ -59,7 +59,7 @@ def run_hmmscan(run: dict[str, Any], gbks: list[Any], start_time: Any) -> None:
             run["cores"],
         )
 
-        with tqdm.tqdm(unit="CDS", total=len(cds_to_scan), desc="HMMSCAN") as t:
+        with tqdm.tqdm(unit="CDS", total=len(cds_to_scan), desc="hmmsearch") as t:
 
             def callback(tasks_done):
                 t.update(tasks_done)

--- a/big_scape/run_bigscape.py
+++ b/big_scape/run_bigscape.py
@@ -12,7 +12,7 @@ from datetime import datetime
 from pathlib import Path
 
 # from other modules
-from big_scape.hmm import HMMer, run_hmmscan, run_hmmalign
+from big_scape.hmm import HMMer, run_hmmsearch, run_hmmalign
 from big_scape.diagnostics import Profiler
 from big_scape.output import (
     legacy_prepare_output,
@@ -151,7 +151,7 @@ def run_bigscape(run: dict) -> None:
 
     logging.info("First task: %s", run_state)
 
-    # we will need this later. this can be set in hmmscan, hmmalign or not at all
+    # we will need this later. this can be set in hmmsearch, hmmalign or not at all
     pfam_info = None
 
     # HMMER - Search/scan
@@ -161,7 +161,7 @@ def run_bigscape(run: dict) -> None:
         # first opportunity to set this is here
         pfam_info = HMMer.get_pfam_info()
 
-        run_hmmscan(run, gbks, start_time)
+        run_hmmsearch(run, gbks, start_time)
 
         # set new run state
         run_state = bs_data.find_minimum_task(gbks)

--- a/test/hmm/test_hmm_scan.py
+++ b/test/hmm/test_hmm_scan.py
@@ -18,8 +18,8 @@ from big_scape.hmm import HSP
 import big_scape.enums as bs_enums
 
 
-class TestHMMScan(TestCase):
-    """Contains tests to check the hmmscan functionality"""
+class TestHMMSearch(TestCase):
+    """Contains tests to check the hmmsearch functionality"""
 
     def clean_db(self):
         if DB.opened():

--- a/test/integration/test_hmm.py
+++ b/test/integration/test_hmm.py
@@ -47,7 +47,7 @@ def add_mock_hsp_alignment_hsp(hsp: bs_hmm.HSP) -> None:
     hsp.alignment = hsp_alignment
 
 
-class TestHMMScan(TestCase):
+class TestHMMSearch(TestCase):
     """Test class for hmm search/scan workflow"""
 
     def clean_db(self):
@@ -142,7 +142,7 @@ class TestHMMScan(TestCase):
         run_state = bs_data.find_minimum_task([gbk])
         self.assertEqual(run_state, bs_enums.TASK.HMM_ALIGN)
 
-    def test_hmmscan_simple_workflow_file(self):
+    def test_hmmsearch_simple_workflow_file(self):
         """Tests the entire hmm scan workflow with a file as input"""
 
         bs_data.DB.create_in_mem()
@@ -198,7 +198,7 @@ class TestHMMScan(TestCase):
         run_state = bs_data.find_minimum_task([gbk])
         self.assertEqual(run_state, bs_enums.TASK.COMPARISON)
 
-    def test_hmmscan_multiprocess_workflow_file(self):
+    def test_hmmsearch_multiprocess_workflow_file(self):
         """Tests the entire hmm scan workflow with a file as input"""
 
         bs_data.DB.create_in_mem()


### PR DESCRIPTION
We're not using hmmscan, we're using hmmsearch. This is an almost 2 year old piece of naming snafu.