### PR TITLE
Fixed typo in cluster cli help text

### DIFF
--- a/big_scape/cli/cluster_cli.py
+++ b/big_scape/cli/cluster_cli.py
@@ -123,7 +123,7 @@ based on the generic 'mix' weights. For more detail, see wiki.
     "--include-singletons",
     is_flag=True,
     help=(
-        "Include singletons in the networ and all respective output."
+        "Include singletons in the network and all respective output."
         " Reference singletons will not be included even if this is toggled."
     ),
 )


### PR DESCRIPTION
What did you change?
Why did you change it? (Please link to issues if available)
How did you implement the change?

Fixed a typo in CLI help text


